### PR TITLE
Decoded logging

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -101,7 +101,7 @@ module Savon
       super unless @wsdl.respond_to? soap_action
 
       setup_objects *@wsdl.operation_from(soap_action), &block
-      Response.new @request.soap(@soap)
+      @request.soap(@soap)
     end
 
     # Expects a SOAP operation Hash and sets up Savon::SOAP and Savon::WSSE. Yields them to a given

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -103,9 +103,9 @@ module Savon
       http.use_ssl = @soap.endpoint.ssl?
 
       log_request
-      @response = http.start do |h|
+      @response = Response.new(http.start do |h|
         h.request request(:soap) { |request| request.body = @soap.to_xml }
-      end
+      end)
       log_response
       @response
     end
@@ -126,8 +126,8 @@ module Savon
 
     # Logs the SOAP response.
     def log_response
-      log "SOAP response (status #{@response.code}):"
-      log @response.body
+      log "SOAP response (status #{@response.http.code}):"
+      log @response.to_s
     end
 
     # Returns a Net::HTTP request for a given +type+. Yields the request to an optional block.

--- a/spec/support/endpoint_helper.rb
+++ b/spec/support/endpoint_helper.rb
@@ -16,6 +16,7 @@ class EndpointHelper
       when :soap_fault then "http://soapfault.example.com/Service?wsdl"
       when :http_error then "http://httperror.example.com/Service?wsdl"
       when :invalid    then "http://invalid.example.com/Service?wsdl"
+      when :gzip       then "http://gzip.example.com/Service?wsdl"
       else                  "http://example.com/validation/1.0/AuthenticationService"
     end
   end

--- a/spec/support/http_stubs.rb
+++ b/spec/support/http_stubs.rb
@@ -4,6 +4,10 @@ FakeWeb.allow_net_connect = false
 FakeWeb.register_uri :get, EndpointHelper.wsdl_endpoint, :body => WSDLFixture.authentication
 FakeWeb.register_uri :post, EndpointHelper.soap_endpoint, :body => ResponseFixture.authentication
 
+# Some WSDL and SOAP request.
+FakeWeb.register_uri :get, EndpointHelper.wsdl_endpoint(:gzip), :body => WSDLFixture.authentication
+FakeWeb.register_uri :post, EndpointHelper.soap_endpoint(:gzip), :body => GzipResponseFixture.message
+
 # WSDL and SOAP request with a Savon::SOAPFault.
 FakeWeb.register_uri :get, EndpointHelper.wsdl_endpoint(:soap_fault), :body => WSDLFixture.authentication
 FakeWeb.register_uri :post, EndpointHelper.soap_endpoint(:soap_fault), :body => ResponseFixture.soap_fault


### PR DESCRIPTION
Fixes #85. The simplest way to get this working was to have Savon::Request return the initialized Savon::Response so that Savon::Request who does the logging has access to the unencoded response body.

This should work for my use cases but looking for feedback.
