### PR TITLE
Wrong header sent when using :gzip => true

### DIFF
--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -50,7 +50,7 @@ module Savon
     def initialize(endpoint, options = {})
       @endpoint = URI endpoint
       @proxy = URI options[:proxy] || ""
-      headers["Accept-encoding"] = "gzip,deflate" if options[:gzip]
+      headers["Accept-Encoding"] = "gzip,deflate" if options[:gzip]
     end
 
     # Returns the endpoint URI.

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -94,7 +94,7 @@ describe Savon::Request do
       @request = Savon::Request.new EndpointHelper.wsdl_endpoint, :gzip => true
       a_post = Net::HTTP::Post.new(@soap.endpoint.request_uri, {})
 
-      Net::HTTP::Post.expects(:new).with(anything, has_entry("Accept-encoding" => "gzip,deflate")).returns(a_post)
+      Net::HTTP::Post.expects(:new).with(anything, has_entry("Accept-Encoding" => "gzip,deflate")).returns(a_post)
 
       @request.soap @soap
     end
@@ -103,7 +103,7 @@ describe Savon::Request do
       @request = Savon::Request.new EndpointHelper.wsdl_endpoint, :gzip => false
       a_post = Net::HTTP::Post.new(@soap.endpoint.request_uri, {})
 
-      Net::HTTP::Post.expects(:new).with(anything, Not(has_entry("Accept-encoding" => "gzip,deflate"))).returns(a_post)
+      Net::HTTP::Post.expects(:new).with(anything, Not(has_entry("Accept-Encoding" => "gzip,deflate"))).returns(a_post)
 
       @request.soap @soap
     end


### PR DESCRIPTION
The correct spelling of "Accept-Encoding" capitalizes the "E", but Savon leaves it lowercase, as in "Accept-encoding".

Since HTTP headers are case-sensitive, this causes problems with clients that expect to see "Accept-Encoding" rather than the lowercase variant.
