### PR TITLE
Fixing an issue with :attributes! getting overriden by a double call

### DIFF
--- a/lib/savon/soap/xml.rb
+++ b/lib/savon/soap/xml.rb
@@ -114,7 +114,7 @@ module Savon
 
       # Returns the SOAP header as an XML String.
       def header_for_xml
-        header.to_soap_xml + wsse_header
+        @header_for_xml ||= header.to_soap_xml + wsse_header
       end
 
       # Returns the WSSE header or an empty String in case WSSE was not set.


### PR DESCRIPTION
Hey,

Once more here I am now with savon. I have noticed that when I used this code the attributes weren't being put on the final XML using this code:

```
response = client.request :nfe_dados_msg, :xmlns => "http://www.portalfiscal.inf.br/nfe/wsdl/NfeStatusServico2" do
  soap.header = {
    :nfeCabecMsg => { :versaoDados => "2.00", :cUF => "31" },
    :attributes! => { :nfeCabecMsg => { :xmlns => 'http://www.portalfiscal.inf.br/nfe/wsdl/NfeStatusServico' } }
  }
end
```

Unless I am doing a very wrong thing here, I guess I am following the pattern you established.

After some debugging I've found that they were getting overridden by a double call as the way you do deletes the :attributes! from the hash right away. The solution is trivial and looks like it works fine. I was unable to reproduce that behavior on the test cases you have in place and would love to implement this test if you can help me.

Thanks for such a great work!
