### PR TITLE
Significant perfomance improvement for very large responses

### DIFF
--- a/lib/savon/soap/fault.rb
+++ b/lib/savon/soap/fault.rb
@@ -19,7 +19,7 @@ module Savon
 
       # Returns whether a SOAP fault is present.
       def present?
-        @present ||= http.body =~ /<(.+:)?Body>(\s*)<(.+:)?Fault>/
+        @present ||= http.body[0,1000] =~ /<(.+:)?Body>(\s*)<(.+:)?Fault>/
       end
 
       # Returns the SOAP fault message.


### PR DESCRIPTION
I'm working with a webservice that returns really large responses (some over 5mb) and after switching from Savon 0.7.9 to 0.8 these took a very long time to process (not sure how long, didn't want to wait for over an hour.)

Turns out this is caused by the regex that checks for a soap fault element. This commit changes the check so that the regex only checks the first 1000 chars of the response string. It should work properly in most (if not all) cases; the tests still pass and the soap fault fixtures range in size from 270 to 672 chars.
