### PR TITLE
Don't include Nonce and Created for PasswordText

### DIFF
--- a/spec/savon/wsse_spec.rb
+++ b/spec/savon/wsse_spec.rb
@@ -118,12 +118,12 @@ describe Savon::WSSE do
         wsse.to_xml.should include("username", "password")
       end
 
-      it "should contain a wsse:Nonce tag" do
-        wsse.to_xml.should match(/<wsse:Nonce>\w+<\/wsse:Nonce>/)
+      it "should not contain a wsse:Nonce tag" do
+        wsse.to_xml.should_not match(/<wsse:Nonce>.*<\/wsse:Nonce>/)
       end
 
-      it "should contain a wsu:Created tag" do
-        wsse.to_xml.should match(/<wsu:Created>#{Savon::SOAP::DateTimeRegexp}.+<\/wsu:Created>/)
+      it "should not contain a wsu:Created tag" do
+        wsse.to_xml.should_not match(/<wsu:Created>.*<\/wsu:Created>/)
       end
 
       it "should contain the PasswordText type attribute" do


### PR DESCRIPTION
Before this change, Savon sends Nonce and Created whether the password type is PasswordText or PasswordDigest.

However, according to http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0.pdf (line 173 on page 9), Nonce and Created should not be sent for PasswordText, and the SOAP server which we are using actually rejects the request if you send Nonce and Created on PasswordText.
