### PR TITLE
Also handle the case where the WSDL has two bindings.

### DIFF
--- a/lib/savon/wsdl/parser.rb
+++ b/lib/savon/wsdl/parser.rb
@@ -66,6 +66,8 @@ module Savon
           # no soapAction attribute found till now
           operation_from tag, "soapAction" => @input
         end
+
+        @section = :definitions if Sections.include?(tag) && depth <= 1
       end
 
       # Stores available operations from a given tag +name+ and +attrs+.

--- a/spec/fixtures/wsdl/two_bindings.xml
+++ b/spec/fixtures/wsdl/two_bindings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example of a WSDL with two <binding> tags ("sections" in Savon
+     parlance).
+
+     This is stripped down from a real example found in the wild, although
+     having different operations for the SOAP 1.1 and SOAP 1.2 bindings
+     is hypothetical (the real-world example I saw had the same operations
+     in each binding section). -->
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <types>
+    </types>
+    <portType name="BlogSoap">
+    </portType>
+    <binding name="BlogSoap">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <operation name="Post" />
+        <operation name="Post11only" />
+    </binding>
+    <binding name="BlogSoap12">
+        <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <operation name="Post" />
+        <operation name="Post12only" />
+    </binding>
+</definitions>
+

--- a/spec/savon/wsdl/parser_spec.rb
+++ b/spec/savon/wsdl/parser_spec.rb
@@ -61,6 +61,15 @@ describe Savon::WSDL::Parser do
     end
   end
 
+  context "with two_bindings.xml" do
+    let(:parser) { new_parser :two_bindings }
+
+    it "should merge operations from all binding sections (until we have an example where it makes sense to do otherwise)" do
+      parser.operations.keys.map(&:to_s).sort.should ==
+        %w{post post11only post12only}
+    end
+  end
+
   RSpec::Matchers.define :match_operations do |expected|
     match do |actual|
       actual.should have(expected.keys.size).items


### PR DESCRIPTION
I encountered a WSDL file which has two <binding> tags (one for SOAP 1.1 and one for SOAP 1.2).

When Savon 0.8.3 parses it, it blows up with

  parser.rb:49:in `tag_start': undefined method`starts_with?' for nil:NilClass (NoMethodError)

The patch that's in this pull request contains a fix and (as part of the Savon specs), a stripped down version of the WSDL that caused the problem.
