### PR TITLE
Support for a nil Body

### DIFF
--- a/lib/savon/soap/xml.rb
+++ b/lib/savon/soap/xml.rb
@@ -135,7 +135,7 @@ module Savon
       def to_xml
         @xml ||= tag(builder, :Envelope, complete_namespaces) do |xml|
           tag(xml, :Header) { xml << header_for_xml } unless header_for_xml.empty?
-          tag(xml, :Body) { xml.tag!(*input) { xml << body_to_xml } }
+          input.nil? ? tag(xml, :Body) : tag(xml, :Body) { xml.tag!(*input) { xml << body_to_xml } }
         end
       end
 


### PR DESCRIPTION
I have some SOAP calls that need to have a nil body (i.e. &lt;Body /&gt;). This is not currently possible because the current Savon::SOAP::XML#to_xml method requires that input not be nil. This small change allows for a nil input.
