### PR TITLE
Set custom SOAPAction Header (No WSDL and default action name not enough)

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -119,7 +119,7 @@ module Savon
     def set_soap_action(input)
       soap_action = wsdl.soap_action input.to_sym
       soap_action ||= input.kind_of?(String) ? input : input.to_s.lower_camelcase
-      http.headers["SOAPAction"] = %{"#{soap_action}"}
+      http.headers["SOAPAction"] ||= %{"#{soap_action}"}
     end
 
     # Expects a +namespace+, +input+ and +attributes+ and sets the SOAP input.

--- a/spec/savon/client_spec.rb
+++ b/spec/savon/client_spec.rb
@@ -226,6 +226,16 @@ describe Savon::Client do
       end
     end
 
+    it "allows custom SOAPAction header to be set to override the default SOAP action name" do
+      HTTPI.stubs(:post).returns(new_response)
+
+      client.http.headers["SOAPAction"] = %{"http://v1_0.ws.auth.order.example.com#authenticate"}
+
+      client.request :authenticate do
+        http.headers["SOAPAction"].should == %{"http://v1_0.ws.auth.order.example.com#authenticate"}
+      end
+    end
+    
     it "should execute SOAP requests and return the response" do
       HTTPI.expects(:post).returns(new_response)
       response = client.request(:authenticate)
@@ -252,6 +262,16 @@ describe Savon::Client do
       end
     end
 
+    it "allows custom SOAPAction header to be set to override the default SOAP action name" do
+      HTTPI.stubs(:post).returns(new_response)
+
+      client.http.headers["SOAPAction"] = %{"http://v1_0.ws.auth.order.example.com#authenticate"}
+
+      client.request :authenticate do
+        http.headers["SOAPAction"].should == %{"http://v1_0.ws.auth.order.example.com#authenticate"}
+      end
+    end
+    
     it "should get #element_form_default from the WSDL" do
       HTTPI.stubs(:post).returns(new_response)
       Savon::WSDL::Document.any_instance.expects(:element_form_default).returns(:qualified)
@@ -290,6 +310,16 @@ describe Savon::Client do
       end
     end
 
+    it "allows custom SOAPAction header to be set to override the default SOAP action name" do
+      HTTPI.stubs(:post).returns(new_response)
+
+      client.http.headers["SOAPAction"] = %{"http://v1_0.ws.auth.order.example.com#authenticate"}
+
+      client.request :authenticate do
+        http.headers["SOAPAction"].should == %{"http://v1_0.ws.auth.order.example.com#authenticate"}
+      end
+    end
+    
     it "should not get #element_form_default from the WSDL" do
       HTTPI.stubs(:post).returns(new_response)
       Savon::WSDL::Document.any_instance.expects(:element_form_default).never


### PR DESCRIPTION
Modified savon/client to allow setting custom SOAPAction header.
Added tests to verify custom SOAPAction in correctly set when provided.

Needed in case where WSDL is not used (for performance) but action requires SOAPAction other than default of SOAP action name.

For example, ran into service where expected SOAPAction was:
http://v1_0.ws.auth.order.example.com#authenticate

Where 'http://v1_0.ws.auth.order.example.com' was 'xmlns:tns' namespace and SOAP action was 'authenticate'.
Without patch, SOAPAction was set to 'authenticate' when not using a WSDL.

A google search turned up that this was a feature of a previous version of Savon but seems to have been removed? Is there a better way to accomplish this in the current version?
