### PR TITLE
Provide a setting for whether SOAP faults can be recognized with HTTP response code 200

### DIFF
--- a/lib/savon/global.rb
+++ b/lib/savon/global.rb
@@ -41,6 +41,14 @@ module Savon
       @raise_errors != false
     end
 
+    # Sets whether to recognize a SOAP fault with an HTTP 
+    # response code of 200. Defaults to +false+.
+    attr_writer :accept_faults_with_200
+
+    def accept_faults_with_200?
+      !!@accept_faults_with_200
+    end
+
     # Sets the global SOAP version.
     def soap_version=(version)
       raise ArgumentError, "Invalid SOAP version: #{version}" unless SOAP::Versions.include? version

--- a/lib/savon/soap/fault.rb
+++ b/lib/savon/soap/fault.rb
@@ -19,7 +19,11 @@ module Savon
 
       # Returns whether a SOAP fault is present.
       def present?
-        @present ||= http.code == 500 && http.body.include?("Fault>") && (soap1_fault? || soap2_fault?)
+        @present ||= response_code_is_acceptable && http.body.include?("Fault>") && (soap1_fault? || soap2_fault?)
+      end
+
+      def response_code_is_acceptable
+        http.code == 500 || Savon.accept_faults_with_200?
       end
 
       # Returns the SOAP fault message.

--- a/spec/savon/soap/fault_spec.rb
+++ b/spec/savon/soap/fault_spec.rb
@@ -33,9 +33,15 @@ describe Savon::SOAP::Fault do
       no_fault.should_not be_present
     end
 
-    it "should return false if the HTTP response code is not 500" do
+    it "by default requires a SOAP fault to have HTTP response code 500" do
       fault = Savon::SOAP::Fault.new new_response(:code => 200, :body => Fixture.response(:soap_fault))
       fault.should_not be_present
+    end
+
+    it "can also optionally accept a SOAP fault with HTTP response code which is not 500" do
+      Savon.stubs(:accept_faults_with_200?).returns(true)
+      fault = Savon::SOAP::Fault.new new_response(:code => 200, :body => Fixture.response(:soap_fault))
+      fault.should be_present
     end
   end
 


### PR DESCRIPTION
Following up on https://github.com/rubiii/savon/issues/issue/151 , here's a fairly minimal fix which just provides a setting for whether to check the response code.

A possibly cleaner solution is to first send the response to crack and then dig through the hash that crack returns to see if it looks like a soap fault, but that seemed like a bigger change and I didn't try it.
