### PR TITLE
log in the case that Crack barfs while parsing SOAP response

### DIFF
--- a/lib/savon/soap/xml.rb
+++ b/lib/savon/soap/xml.rb
@@ -28,7 +28,12 @@ module Savon
 
       # Converts a given SOAP response +xml+ to a Hash.
       def self.parse(xml)
-        Crack::XML.parse(xml) rescue {}
+        begin
+          Crack::XML.parse(xml) 
+        rescue Exception=>e
+          Savon.log(e)
+          {}
+        end
       end
 
       # Expects a SOAP response XML or Hash, traverses it for a given +path+ of Hash keys


### PR DESCRIPTION
currently Savon::SOAP::XML.parse swallows any Exceptions from Crack silently. this is evil

this patch logs any Crack Exceptions to Savon.log. I would prefer that Exceptions should propagate to caller, but presumably you took a decision not to do this for some reason, in which case logging is appropriate

:c
