### PR TITLE
Allow WSSE to include both a timestamp and credentials

### DIFF
--- a/lib/savon/wsse.rb
+++ b/lib/savon/wsse.rb
@@ -68,12 +68,15 @@ module Savon
 
     # Returns the XML for a WSSE header.
     def to_xml
-      if username_token?
-        Gyoku.xml wsse_username_token.merge!(hash)
-      elsif timestamp?
-        Gyoku.xml wsse_timestamp.merge!(hash)
-      else
+      @wsse_security = {}
+
+      wsse_username_token if username_token?
+      wsse_timestamp if timestamp?  
+      
+      if @wsse_security.blank?
         ""
+      else
+        Gyoku.xml @wsse_security
       end
     end
 
@@ -103,15 +106,21 @@ module Savon
         "wsu:Expires" => (expires_at || (created_at || Time.now) + 60).xs_datetime
     end
 
-    # Returns a Hash containing wsse:Security details for a given +tag+ and +hash+.
+    # Returns a Hash building wsse:Security details with a given +tag+ and +hash+.
     def wsse_security(tag, hash)
-      {
-        "wsse:Security" => {
-          "wsse:#{tag}" => hash,
-          :attributes! => { "wsse:#{tag}" => { "wsu:Id" => "#{tag}-#{count}", "xmlns:wsu" => WSUNamespace } }
-        },
-        :attributes! => { "wsse:Security" => { "xmlns:wsse" => WSENamespace } }
-      }
+      if @wsse_security.blank?
+        @wsse_security = {
+          "wsse:Security" => {
+            :attributes! => {}
+            },
+            :attributes! => { "wsse:Security" => { "xmlns:wsse" => WSENamespace } }
+        } 
+      end
+
+      @wsse_security["wsse:Security"]["wsse:#{tag}"] = hash
+      @wsse_security["wsse:Security"][:attributes!]["wsse:#{tag}"] = { "wsu:Id" => "#{tag}-#{count}", "xmlns:wsu" => WSUNamespace }
+      
+      @wsse_security
     end
 
     # Returns the WSSE password, encrypted for digest authentication.

--- a/spec/savon/wsse_spec.rb
+++ b/spec/savon/wsse_spec.rb
@@ -5,22 +5,22 @@ describe Savon::WSSE do
 
   it "should contain the namespace for WS Security Secext" do
     Savon::WSSE::WSENamespace.should ==
-      "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+    "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
   end
 
   it "should contain the namespace for WS Security Utility" do
     Savon::WSSE::WSUNamespace.should ==
-      "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+    "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
   end
 
   it "should contain the namespace for the PasswordText type" do
     Savon::WSSE::PasswordTextURI.should ==
-      "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"
+    "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordText"
   end
 
   it "should contain the namespace for the PasswordDigest type" do
     Savon::WSSE::PasswordDigestURI.should ==
-      "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest"
+    "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest"
   end
 
   describe "#credentials" do
@@ -159,12 +159,28 @@ describe Savon::WSSE do
       end
     end
 
+    context "with credentials and #timestamp" do
+      before do 
+        wsse.credentials "username", "password"
+        wsse.timestamp = true
+      end
+
+      it "should contain a wsu:Id attribute" do
+        wsse.to_xml.should include('<wsse:UsernameToken wsu:Id="UsernameToken-1"')
+      end
+
+      it "should contain a wsse:Timestamp node" do
+        wsse.to_xml.should include('<wsse:Timestamp wsu:Id="Timestamp-2" ' +
+        'xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">')
+      end
+    end
+
     context "with #timestamp set to true" do
       before { wsse.timestamp = true }
 
       it "should contain a wsse:Timestamp node" do
         wsse.to_xml.should include('<wsse:Timestamp wsu:Id="Timestamp-1" ' +
-          'xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">')
+        'xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">')
       end
 
       it "should contain a wsu:Created node defaulting to Time.now" do


### PR DESCRIPTION
At the moment you can either pass through a timestamp, or (digested) credentials. If you pass both, the credentials will wipe out the timestamp.

I've updated this as to allow both.
