### PR TITLE
Remove old converter. This is moved to gyoku

### DIFF
--- a/lib/savon/global.rb
+++ b/lib/savon/global.rb
@@ -61,14 +61,6 @@ module Savon
     # Sets whether to strip namespaces in a SOAP response Hash.
     attr_writer :strip_namespaces
 
-    # Returns the current action_converter
-    attr_reader :converter
-
-    # Sets both action_converter and input_converter, converter should be a proc.
-    def converter=(converter)
-      @converter = converter
-    end
-
     # Returns the global env_namespace.
     attr_reader :env_namespace
 
@@ -89,3 +81,4 @@ module Savon
 
   end
 end
+


### PR DESCRIPTION
This removes unused converter from this commit https://github.com/rubiii/savon/commit/37101362f4dafc1e492584fa44ae23e8e750f0be.
