### PR TITLE
Add env_namespace to the reset_config! method

### DIFF
--- a/lib/savon/global.rb
+++ b/lib/savon/global.rb
@@ -75,6 +75,7 @@ module Savon
       self.raise_errors = true
       self.soap_version = SOAP::DefaultVersion
       self.strip_namespaces = true
+      self.env_namespace = nil
     end
 
   end


### PR DESCRIPTION
I forgot this in my previous commit. I guess setting it to nil is good? That is what is checked in soap/xml.rb later on.
