### PR TITLE
Add support for setting a global soap header

### DIFF
--- a/lib/savon/global.rb
+++ b/lib/savon/global.rb
@@ -67,6 +67,12 @@ module Savon
     # Sets the global env_namespace.
     attr_writer :env_namespace
 
+    # Returns the global soap_header.
+    attr_reader :soap_header
+
+    # Sets the global soap_header.
+    attr_writer :soap_header
+
     # Reset to default configuration.
     def reset_config!
       self.log = true
@@ -76,6 +82,7 @@ module Savon
       self.soap_version = SOAP::DefaultVersion
       self.strip_namespaces = true
       self.env_namespace = nil
+      self.soap_header = {}
     end
 
   end

--- a/lib/savon/soap/xml.rb
+++ b/lib/savon/soap/xml.rb
@@ -74,7 +74,7 @@ module Savon
 
       # Returns the SOAP +header+. Defaults to an empty Hash.
       def header
-        @header ||= {}
+        @header ||= Savon.soap_header.nil? ? {} : Savon.soap_header
       end
 
       # Sets the SOAP envelope namespace.

--- a/spec/savon/soap/xml_spec.rb
+++ b/spec/savon/soap/xml_spec.rb
@@ -116,6 +116,11 @@ describe Savon::SOAP::XML do
       xml.header = { "MySecret" => "abc" }
       xml.header.should == { "MySecret" => "abc" }
     end
+
+    it "should use the global soap_header if set" do
+      Savon.stubs(:soap_header).returns({ "MySecret" => "abc" })
+      xml.header.should == { "MySecret" => "abc" }
+    end
   end
 
   describe "#env_namespace" do


### PR DESCRIPTION
In response to issue #138 https://github.com/rubiii/savon/issues/138

Adds a soap_header attribute to Savon and uses this in soap/xml if set.
