### PR TITLE
For parsing WSDL, switch from REXML to Nokogiri and stream parsing to DOM

### DIFF
--- a/lib/savon/wsdl/document.rb
+++ b/lib/savon/wsdl/document.rb
@@ -1,4 +1,4 @@
-require "rexml/document"
+require "nokogiri"
 
 require "savon/wsdl/request"
 require "savon/wsdl/parser"
@@ -101,8 +101,8 @@ module Savon
       # Parses the WSDL document and returns the <tt>Savon::WSDL::Parser</tt>.
       def parser
         @parser ||= begin
-          parser = Parser.new
-          REXML::Document.parse_stream document, parser
+          parser = Parser.new(Nokogiri::XML(document))
+          parser.parse
           parser
         end
       end

--- a/lib/savon/wsdl/parser.rb
+++ b/lib/savon/wsdl/parser.rb
@@ -6,13 +6,14 @@ module Savon
 
     # = Savon::WSDL::Parser
     #
-    # Serves as a stream listener for parsing WSDL documents.
+    # Parses WSDL documents and remembers the parts of them we care about.
     class Parser
 
       # The main sections of a WSDL document.
       Sections = %w(definitions types message portType binding service)
 
-      def initialize
+      def initialize(nokogiri_document)
+        @document = nokogiri_document
         @path = []
         @operations = {}
         @namespaces = {}
@@ -31,70 +32,63 @@ module Savon
       # Returns the elementFormDefault value.
       attr_reader :element_form_default
 
-      # Hook method called when the stream parser encounters a starting tag.
-      def tag_start(tag, attrs)
-        # read xml namespaces if root element
-        read_namespaces(attrs) if @path.empty?
-
-        tag, namespace = tag.split(":").reverse
-        @path << tag
-
-        if @section == :types && tag == "schema"
-          @element_form_default = attrs["elementFormDefault"].to_sym if attrs["elementFormDefault"]
-        end
-
-        if @section == :binding && tag == "binding"
-          # ensure that we are in an wsdl/soap namespace
-          @section = nil unless @namespaces[namespace].starts_with? "http://schemas.xmlsoap.org/wsdl/soap"
-        end
-
-        @section = tag.to_sym if Sections.include?(tag) && depth <= 2
-
-        @namespace ||= attrs["targetNamespace"] if @section == :definitions
-        @endpoint ||= URI(URI.escape(attrs["location"])) if @section == :service && tag == "address"
-
-        operation_from tag, attrs if @section == :binding && tag == "operation"
+      def parse
+        parse_namespaces
+        parse_endpoint
+        parse_operations
       end
 
-      # Returns our current depth in the WSDL document.
-      def depth
-        @path.size
+      def parse_namespaces
+        element_form_default = @document.at_xpath(
+          "s0:definitions/s0:types/xs:schema/@elementFormDefault",
+          "s0" => "http://schemas.xmlsoap.org/wsdl/",
+          "xs" => "http://www.w3.org/2001/XMLSchema")
+        @element_form_default = element_form_default.to_s.to_sym if element_form_default
+
+        namespace = @document.at_xpath(
+          "s0:definitions/@targetNamespace",
+          "s0" => "http://schemas.xmlsoap.org/wsdl/")
+        @namespace = namespace.to_s if namespace
       end
 
-      # Reads namespace definitions from a given +attrs+ Hash.
-      def read_namespaces(attrs)
-        attrs.each do |key, value|
-          @namespaces[key.strip_namespace] = value if key.starts_with? "xmlns:"
+      def parse_endpoint
+        endpoint = @document.at_xpath(
+          "s0:definitions/s0:service//soap11:address/@location",
+          "s0" => "http://schemas.xmlsoap.org/wsdl/",
+          "soap11" => "http://schemas.xmlsoap.org/wsdl/soap/")
+        endpoint ||= @document.at_xpath(
+          "s0:definitions/s0:service//soap12:address/@location",
+          "s0" => "http://schemas.xmlsoap.org/wsdl/",
+          "soap12" => "http://schemas.xmlsoap.org/wsdl/soap12/")
+        @endpoint = URI(URI.escape(endpoint.to_s)) if endpoint
+      end
+
+      def parse_operations
+        operations = @document.xpath(
+          "s0:definitions/s0:binding/s0:operation",
+          "s0" => "http://schemas.xmlsoap.org/wsdl/")
+        operations.each do |operation|
+          name = operation.attribute("name").to_s
+
+          soap_action = operation.at_xpath(".//soap11:operation/@soapAction",
+            "soap11" => "http://schemas.xmlsoap.org/wsdl/soap/"
+          )
+          soap_action ||= operation.at_xpath(".//soap12:operation/@soapAction",
+            "soap12" => "http://schemas.xmlsoap.org/wsdl/soap12/"
+          )
+          if soap_action
+            soap_action = soap_action.to_s
+
+            action = !soap_action.blank? ? soap_action : name
+            input = (!name || name.empty?) ? action.split("/").last : name
+
+            @operations[input.snakecase.to_sym] =
+              { :action => action, :input => input }
+          elsif !@operations[name.snakecase.to_sym]
+            @operations[name.snakecase.to_sym] =
+              { :action => name, :input => name }
+          end
         end
-      end
-
-      # Hook method called when the stream parser encounters a closing tag.
-      def tag_end(tag)
-        @path.pop
-
-        if @section == :binding && @input && tag.strip_namespace == "operation"
-          # no soapAction attribute found till now
-          operation_from tag, "soapAction" => @input
-        end
-
-        @section = :definitions if Sections.include?(tag) && depth <= 1
-      end
-
-      # Stores available operations from a given tag +name+ and +attrs+.
-      def operation_from(tag, attrs)
-        @input = attrs["name"] if attrs["name"]
-
-        if attrs["soapAction"]
-          @action = !attrs["soapAction"].blank? ? attrs["soapAction"] : @input
-          @input = @action.split("/").last if !@input || @input.empty?
-
-          @operations[@input.snakecase.to_sym] = { :action => @action, :input => @input }
-          @input, @action = nil, nil
-        end
-      end
-
-      # Catches calls to unimplemented hook methods.
-      def method_missing(method, *args)
       end
 
     end

--- a/savon.gemspec
+++ b/savon.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "crack", "~> 0.1.8"
   s.add_dependency "httpi", ">= 0.7.8"
   s.add_dependency "gyoku", ">= 0.4.0"
+  s.add_dependency "nokogiri"
 
   s.add_development_dependency "rspec", "~> 2.4.0"
   s.add_development_dependency "autotest"

--- a/spec/fixtures/wsdl/soap12.xml
+++ b/spec/fixtures/wsdl/soap12.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example of a WSDL with SOAP 1.2 and no SOAP 1.1 endpoint.
+     Don't know whether this is widespread, but we should allow it. -->
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <service name="Blog">
+        <port name="BlogSoap12">
+            <soap12:address location="http://blogsite.example.com/endpoint12"/>
+        </port>
+    </service>
+</definitions>
+

--- a/spec/savon/wsdl/parser_spec.rb
+++ b/spec/savon/wsdl/parser_spec.rb
@@ -82,6 +82,14 @@ describe Savon::WSDL::Parser do
     end
   end
 
+  context "with soap12.xml" do
+    let(:parser) { new_parser :soap12 }
+
+    it "should return the endpoint" do
+      parser.endpoint.should == URI("http://blogsite.example.com/endpoint12")
+    end
+  end
+
   RSpec::Matchers.define :match_operations do |expected|
     match do |actual|
       actual.should have(expected.keys.size).items
@@ -91,8 +99,8 @@ describe Savon::WSDL::Parser do
   end
 
   def new_parser(fixture)
-    parser = Savon::WSDL::Parser.new
-    REXML::Document.parse_stream Fixture[:wsdl, fixture], parser
+    parser = Savon::WSDL::Parser.new(Nokogiri::XML(Fixture[:wsdl, fixture]))
+    parser.parse
     parser
   end
 


### PR DESCRIPTION
I know that switching to nokogiri has been a TODO. Not sure whether the intention was to
switch away from stream parsing too, but the current parser is quite ugly (in ways which are
hard to fix using stream parsing, and which gets far worse in my branch where I try to parse
types). So this patch switches to nokogiri and also switches away from stream parsing.
