### PR TITLE
incompatibility with httpi 0.9.3

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "builder",  ">= 2.1.2"
   s.add_dependency "nori",     ">= 0.2.0"
-  s.add_dependency "httpi",    ">= 0.7.8"
+  s.add_dependency "httpi",    "0.9.2"
   s.add_dependency "gyoku",    ">= 0.4.0"
   s.add_dependency "nokogiri", ">= 1.4.0"
 


### PR DESCRIPTION
changing httpi dependency to be fixed at v0.9.2, since savon don't work with httpi v0.9.3. it's best to let it fixed at one version since httpi showed to be a lot unstable(see issues #161, #165, #163, #93). following the stacktrace:

```
 httpi (0.9.3) lib/httpi/adapter/net_http.rb:110:in `respond_with'
 httpi (0.9.3) lib/httpi/adapter/net_http.rb:76:in `do_request'
 httpi (0.9.3) lib/httpi/adapter/net_http.rb:22:in `get'
 httpi (0.9.3) lib/httpi.rb:86:in `block in get'
 httpi (0.9.3) lib/httpi.rb:189:in `with_adapter'
 httpi (0.9.3) lib/httpi.rb:84:in `get'
 savon (0.9.2) lib/savon/wsdl/request.rb:21:in `block in response'
 savon (0.9.2) lib/savon/wsdl/request.rb:30:in `with_logging'
 savon (0.9.2) lib/savon/wsdl/request.rb:21:in `response'
 savon (0.9.2) lib/savon/wsdl/document.rb:93:in `http_request'
 savon (0.9.2) lib/savon/wsdl/document.rb:77:in `document'
 savon (0.9.2) lib/savon/wsdl/document.rb:104:in `parser'
 savon (0.9.2) lib/savon/wsdl/document.rb:38:in `endpoint'
 savon (0.9.2) lib/savon/client.rb:112:in `preconfigure'
 savon (0.9.2) lib/savon/client.rb:78:in `request'
```
