### PR TITLE
Fix thinko in xml.input = [:simple] spec

### DIFF
--- a/spec/savon/soap/xml_spec.rb
+++ b/spec/savon/soap/xml_spec.rb
@@ -253,7 +253,7 @@ describe Savon::SOAP::XML do
 
     context "with a simple input tag (Array)" do
       it "should just add the input tag" do
-        xml.input = :simple
+        xml.input = [:simple]
         xml.to_xml.should include('<simple><id>1</id></simple>')
       end
     end


### PR DESCRIPTION
This is just a case where the description of the spec doesn't match the actual code of the spec. Without this patch, the spec is the same as the one above it, but based on the context I'm relatively sure this patch is what was intended.
