### PR TITLE
Fix for https://github.com/rubiii/savon_spec/issues/2

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -110,7 +110,7 @@ module Savon
       soap.namespace_identifier = args[0]
       soap.namespace = wsdl.namespace
       soap.element_form_default = wsdl.element_form_default if wsdl.document?
-      soap.body = args[2].delete(:body)
+      soap.body = args[2].delete(:body) if args[2][:body]
 
       wsdl.type_namespaces.each do |path, uri|
         soap.use_namespace(path, uri)


### PR DESCRIPTION
After this one line fix savon_spec works with the latest savon release (0.9.6).  This appears to have been a regression starting with 0.9.3 (when the line was changed and the conditional removed).
