### PR TITLE
Add log_filter to filter out sensitive element values

### DIFF
--- a/lib/savon/global.rb
+++ b/lib/savon/global.rb
@@ -30,7 +30,26 @@ module Savon
 
     # Logs a given +message+.
     def log(message)
-      logger.send log_level, message if log?
+      logger.send log_level, filtered(message) if log?
+    end
+
+    # Sets the log filter.
+    attr_writer :log_filter
+
+    # Returns the log filter. Defaults to blank.
+    def log_filter
+      @log_filter ||= ''
+    end
+
+    # Filters Message based on log filter
+    def filtered(message)
+      xml = Nokogiri::XML(message)
+      return message if @log_filter.empty? || !xml.errors.empty?
+
+      @log_filter.each do |filter|
+        xml.xpath("//*[local-name()='#{filter}']").map { |node| node.content = '***FILTERED***' }
+      end
+      return xml.root.to_s
     end
 
     # Sets whether to raise HTTP errors and SOAP faults.
@@ -102,6 +121,7 @@ module Savon
       self.strip_namespaces = true
       self.env_namespace = nil
       self.soap_header = {}
+      self.log_filter = ''
     end
 
   end

--- a/spec/savon/savon_spec.rb
+++ b/spec/savon/savon_spec.rb
@@ -33,6 +33,67 @@ describe Savon do
       end
     end
 
+    describe "log filter" do
+
+      context "without a log filter set" do
+        it "should not filter XML messages" do
+          filtered_message = Savon.filtered(Fixture.response(:authentication))
+          filtered_message.should == Fixture.response(:authentication)
+        end
+
+        it "should not filter non-XML messages" do
+          filtered_message = Savon.filtered('This is an information message.')
+          filtered_message.should == 'This is an information message.'
+        end
+      end
+
+      context "with a log filter set" do
+        before(:each) do
+          Savon.configure { |config| config.log_filter = ['tokenHash'] }
+        end
+
+        it "should set log filter" do
+          Savon.log_filter.should == ['tokenHash']
+        end
+
+        it "should filter element values" do
+          filtered_value = "AAAJxA;cIedoT;mY10ExZwG6JuKgp2OYKxow=="
+          filtered_message = Savon.filtered(Fixture.response(:authentication))
+          filtered_message.should_not include(filtered_value)
+          filtered_message.should include('***FILTERED***')
+        end
+
+        it "should not filter non-XML messages" do
+          filtered_message = Savon.filtered('This is an information message.')
+          filtered_message.should == 'This is an information message.'
+        end
+      end
+
+      context "with multiple log filters set" do
+        before(:each) do
+          Savon.configure { |config| config.log_filter = ['logType','logTime'] }
+        end
+
+        it "should filter element values" do
+          filtered_values = /Notes Log|2010-09-21T18:22:01|2010-09-21T18:22:07/
+          filtered_message = Savon.filtered(Fixture.response(:list))
+
+          filtered_message.should_not =~ filtered_values
+          filtered_message.should include('<ns10:logTime>***FILTERED***</ns10:logTime>')
+          filtered_message.should include('<ns10:logType>***FILTERED***</ns10:logType>')
+          filtered_message.should include('<ns11:logTime>***FILTERED***</ns11:logTime>')
+          filtered_message.should include('<ns11:logType>***FILTERED***</ns11:logType>')
+        end
+
+        it "should not filter non-XML messages" do
+          filtered_message = Savon.filtered('This is an information message.')
+
+          filtered_message.should == 'This is an information message.'
+        end
+      end
+
+    end
+
     describe "log_level" do
       it "should default to :debug" do
         Savon.log_level.should == :debug


### PR DESCRIPTION
I needed to log messages, but wanted to filter out sensitive element values (i.e. credit card numbers, etc).

This patch adds a log_filter configuration variable - which takes an array of strings.  The filter will find xml elements (while ignoring namespaces) in log_filter array and will replace it with "***FILTERED***".

Tests included as well.
