### PR TITLE
Gracefully handle invalid response bodies

### DIFF
--- a/lib/savon/soap/invalid_response_error.rb
+++ b/lib/savon/soap/invalid_response_error.rb
@@ -1,0 +1,11 @@
+require "savon/error"
+
+module Savon
+  module SOAP
+    # = Savon::SOAP::InvalidResponseError
+    #
+    # Represents an error when the response was not a valid SOAP envelope.
+    class InvalidResponseError < Error
+    end
+  end
+end

--- a/lib/savon/soap/response.rb
+++ b/lib/savon/soap/response.rb
@@ -1,5 +1,6 @@
 require "savon/soap/xml"
 require "savon/soap/fault"
+require "savon/soap/invalid_response_error"
 require "savon/http/error"
 
 module Savon
@@ -50,11 +51,17 @@ module Savon
 
       # Returns the SOAP response header as a Hash.
       def header
+        if !hash.has_key? :envelope
+          raise Savon::SOAP::InvalidResponseError, "Unable to parse response body '#{to_xml}'"
+        end
         hash[:envelope][:header]
       end
 
       # Returns the SOAP response body as a Hash.
       def body
+        if !hash.has_key? :envelope
+          raise Savon::SOAP::InvalidResponseError, "Unable to parse response body '#{to_xml}'"
+        end
         hash[:envelope][:body]
       end
 

--- a/spec/savon/soap/response_spec.rb
+++ b/spec/savon/soap/response_spec.rb
@@ -121,12 +121,20 @@ describe Savon::SOAP::Response do
       soap_response[:authenticate_response][:return].should ==
         Fixture.response_hash(:authentication)[:authenticate_response][:return]
     end
+
+    it "should throw an exception when the response body isn't parsable" do
+      lambda { invalid_soap_response.body }.should raise_error Savon::SOAP::InvalidResponseError
+    end
   end
 
   describe "#header" do
     it "should return the SOAP response header as a Hash" do
       response = soap_response :body => Fixture.response(:header)
       response.header.should include(:session_number => "ABCD1234")
+    end
+
+    it "should throw an exception when the response header isn't parsable" do
+      lambda { invalid_soap_response.header }.should raise_error Savon::SOAP::InvalidResponseError
     end
   end
 
@@ -219,6 +227,13 @@ describe Savon::SOAP::Response do
 
   def http_error_response
     soap_response :code => 404, :body => "Not found"
+  end
+
+  def invalid_soap_response(options={})
+    defaults = { :code => 200, :headers => {}, :body => "I'm not SOAP" } 
+    response = defaults.merge options
+
+    Savon::SOAP::Response.new HTTPI::Response.new(response[:code], response[:headers], response[:body])
   end
 
 end


### PR DESCRIPTION
Instead of having a nil pointer exception thrown when the response
doesn't contain an <envelope> tag as assumed, throw an
InvalidResponseError, allowing client applications to better handle
unexpectedly bad responses from some SOAP server.

Liauw Fendy lfendy@thoughtworks.com
Sam Gibson sam.gibson@thoughtworks.com
