### PR TITLE
The Content-Length header should be the size in bytes

### DIFF
--- a/lib/savon/soap/request.rb
+++ b/lib/savon/soap/request.rb
@@ -40,7 +40,7 @@ module Savon
         http.url = soap.endpoint
         http.body = soap.to_xml
         http.headers["Content-Type"] = ContentType[soap.version]
-        http.headers["Content-Length"] = soap.to_xml.length.to_s
+        http.headers["Content-Length"] = soap.to_xml.bytesize.to_s
         http
       end
 


### PR DESCRIPTION
From http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

The Content-Length entity-header field indicates the size of the entity-body, in decimal number of OCTETs, sent to the recipient or, in the case of the HEAD method, the size of the entity-body that would have been sent had the request been a GET.
