### PR TITLE
Disable HTTP GET/POST logging if Savon logging is disabled

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -42,6 +42,7 @@ module Savon
 
     # Returns the <tt>HTTPI::Request</tt>.
     def http
+      HTTPI.log = Savon.log?
       @http ||= HTTPI::Request.new
     end
 


### PR DESCRIPTION
Without this when Savon logging has been disabled I still get:

D, [2012-01-03T08:09:50.158495 #13083] DEBUG -- : HTTPI executes HTTP GET using the httpclient adapter
D, [2012-01-03T08:09:50.595625 #13083] DEBUG -- : HTTPI executes HTTP POST using the httpclient adapter

I'm running savon 0.9.7, apologies if this already has been addressed in more elegant way.
