### PR TITLE
Raise an error if fetching a remote WSDL fails

### DIFF
--- a/lib/savon/wasabi/document.rb
+++ b/lib/savon/wasabi/document.rb
@@ -30,7 +30,13 @@ module Savon
       # Resolves and returns the raw WSDL document.
       def resolve_document
         case document
-          when /^http[s]?:/ then HTTPI.get(request).body
+          when /^http[s]?:/ then 
+            response = HTTPI.get(request)
+            if response.error?
+              raise Savon::HTTP::Error.new(response)
+            else
+              response.body
+            end
           when /^</         then document
           else                   File.read(document)
         end

--- a/spec/savon/wasabi/document_spec.rb
+++ b/spec/savon/wasabi/document_spec.rb
@@ -17,6 +17,19 @@ describe Savon::Wasabi::Document do
       wsdl = Savon::Wasabi::Document.new("https://example.com?wsdl")
       wsdl.xml.should == Fixture.wsdl(:authentication)
     end
+
+  end
+
+  context "with an inaccessible remote document" do
+    before do
+      response = HTTPI::Response.new 401, {}, Fixture.wsdl(:authentication)
+      HTTPI.stubs(:get).returns(response)
+    end
+
+    it "should raise an error when authentication fails" do
+      wsdl = Savon::Wasabi::Document.new("http://example.com?wsdl")
+      expect { wsdl.xml }.to raise_error(Savon::HTTP::Error)
+    end
   end
 
   context "with a local document" do


### PR DESCRIPTION
Current behaviour of fetching a remote WSDL is to ignore HTTP errors. This leads to the meaningless error from #236.

This patch adds a check against HTTP errors and raises the standard Savon::HTTP::Error
