### PR TITLE
Soap action can be set via the :soap_action key.

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -122,7 +122,8 @@ module Savon
         soap.types[path] = type
       end
 
-      set_soap_action args[1]
+      soap_action = args[2].delete(:soap_action) || args[1]
+      set_soap_action soap_action
       set_soap_input *args
     end
 

--- a/spec/savon/client_spec.rb
+++ b/spec/savon/client_spec.rb
@@ -112,6 +112,10 @@ describe Savon::Client do
       it "should set the input tag to result in <getUser active='true'>" do
         client.request(:get_user, :active => true) { soap.input.should == [nil, :getUser, { :active => true }] }
       end
+
+      it "should use the :soap_action key to set the SOAPAction header" do
+        client.request(:get_user, :soap_action => :test_action) { http.headers["SOAPAction"].should == %{"testAction"} }
+      end
     end
 
     context "with two Symbols" do
@@ -137,6 +141,10 @@ describe Savon::Client do
     context "with two Symbols and a Hash" do
       it "should set the input tag to result in <wsdl:getUser active='true'>" do
         client.request(:wsdl, :get_user, :active => true) { soap.input.should == [:wsdl, :getUser, { :active => true }] }
+      end
+
+      it "should use the :soap_action key to set the SOAPAction header" do
+        client.request(:wsdl, :get_user, :soap_action => :test_action) { http.headers["SOAPAction"].should == %{"testAction"} }
       end
     end
 


### PR DESCRIPTION
Currently, the symbol you pass to the `Savon::Client#request` method is used in both looking up the soap action in the WSDL, as well as creating the first element in the soap body.  I'm using a service who's first element of the soap body is _not_ the same as the soap action's name.  As far as I could tell, there was no easy way to accomplish this with the current code base.

One possibility is explicitly setting the `SOAPAction` header inside the request block, after the preconfigure has ran.  I didn't like that option because the WSDL already has the soap action, and I don't like repeating it in the code.  I like the automatic lookup that happens when you pass in a symbol.

For this reason, I've added a `:soap_action` option in the hash parameter of the `#request` method.  Having the soap action name and first element of the soap body being different probably goes against the standard, but there are services out there that are written this way, and there was no "easy" way to do this with Savon.
