### PR TITLE
Fixes gemspec problems when bundling under jruby 1.6.5

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 lib = File.expand_path("../lib", __FILE__)
 $:.unshift lib unless $:.include? lib
 
@@ -28,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "timecop", "~> 0.3.5"
 
   s.add_development_dependency "autotest"
-  s.add_development_dependency "ZenTest", "4.5.0"
+  s.add_development_dependency "ZenTest", "= 4.5.0"
 
   s.files = `git ls-files`.split("\n")
   s.require_path = "lib"


### PR DESCRIPTION
Fixes a parsing bug in jruby 1.6.5 in "ruby 1.8" mode:

```
Invalid gemspec in [/home/bamboo/gemcache/jruby/1.8/specifications/savon-0.9.8.gemspec]: Illformed requirement ["#<YAML::Yecht::DefaultKey:0xa306e2> 4.5.0"]
```

Greetz,
Frank
