### PR TITLE
Add namespaces to body and order

### DIFF
--- a/lib/savon/soap/xml.rb
+++ b/lib/savon/soap/xml.rb
@@ -214,6 +214,7 @@ module Savon
                 add_namespaces_to_body(value, types[newpath] ? [types[newpath]] : newpath)
             )
           else
+            add_namespaces_to_values(value, path) if key == :order!
             newhash.merge(key => value)
           end
         end
@@ -224,6 +225,14 @@ module Savon
         [used_namespaces[[input[1].to_s]], input[1], input[2]]
       end
 
+      def add_namespaces_to_values(values, path)
+        values.collect! { |value|
+          camelcased_value = Gyoku::XMLKey.create(value)
+          namespace_path = path + [camelcased_value.to_s]
+          namespace = used_namespaces[namespace_path]
+          "#{namespace.blank? ? '' : namespace + ":"}#{camelcased_value}"
+        }
+      end
     end
   end
 end

--- a/spec/savon/soap/xml_spec.rb
+++ b/spec/savon/soap/xml_spec.rb
@@ -323,13 +323,25 @@ describe Savon::SOAP::XML do
       xml.used_namespaces.merge!({
         ["authenticate", "id"] =>"ns0",
         ["authenticate", "name"] =>"ns1",
-        ["authenticate", "name", "first"] =>"ns2"
+        ["authenticate", "name", "firstName"] =>"ns2"
       })
     end
 
     it "adds namespaces" do
-      body = {:id => 1, :name => {:first => 'Bob'}}
-      xml.send(:add_namespaces_to_body, body).should == {"ns0:id" => "1", "ns1:name" => {"ns2:first" => "Bob"}}
+      body = {:id => 1, :name => {:first_name => 'Bob'}}
+      xml.send(:add_namespaces_to_body, body).should == {"ns0:id" => "1", "ns1:name" => {"ns2:firstName" => "Bob"}}
+    end
+
+    it "adds namespaces to order! list" do
+      body = {:id => 1, :name => {:first_name => 'Bob', :order! => [:first_name]}, :order! => [:id, :name]}
+      xml.send(:add_namespaces_to_body, body).should == {
+        "ns0:id" => "1",
+        "ns1:name" => {
+          "ns2:firstName" => "Bob",
+          :order! => ["ns2:firstName"]
+        },
+        :order! => ["ns0:id", "ns1:name"]
+      }
     end
   end
 


### PR DESCRIPTION
When using a Hash to construct the SOAP body and forcing the order of elements with `:order!` and the body elements are namespaced, Gyoku raises an `ArgumentError`:

```
Missing elements in :order!
```

`Savon::SOAP::XML#add_namespaces_to_body` adds namespaces to the names of elements in the SOAP body, causing them to become out of sync with the element names in the :order! list.

These changes add namespaces to the values in :order! elements as well, so the names match their counterparts in the body Hash before being sent off to Gyoku.

They also add a few tests for the private `add_namespaces_to_body` method, which was far the easiest way to setup tests for this case.

Fixes #238.
