### PR TITLE
Sets the namespace using information from the operation and wsdl namespa...

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -107,8 +107,6 @@ module Savon
     # Expects an Array of +args+ to preconfigure the system.
     def preconfigure(args)
       soap.endpoint = wsdl.endpoint
-      soap.namespace_identifier = args[0]
-      soap.namespace = wsdl.namespace
       soap.element_form_default = wsdl.element_form_default
 
       body = args[2].delete(:body)
@@ -124,6 +122,18 @@ module Savon
 
       soap_action = args[2].delete(:soap_action) || args[1]
       set_soap_action soap_action
+
+      if wsdl.document? && (operation = wsdl.operations[args[1]]) && operation[:namespace_identifier]
+        soap.namespace_identifier = operation[:namespace_identifier].to_sym
+        soap.namespace = wsdl.parser.namespaces[soap.namespace_identifier.to_s]
+
+        # Override nil namespace with one specified in WSDL
+        args[0] = soap.namespace_identifier unless args[0]
+      else
+        soap.namespace_identifier = args[0]
+        soap.namespace = wsdl.namespace
+      end
+
       set_soap_input *args
     end
 

--- a/spec/savon/client_spec.rb
+++ b/spec/savon/client_spec.rb
@@ -100,6 +100,24 @@ describe Savon::Client do
 
         client.request(:get_user) { soap.namespace = nil }
       end
+
+      context "when the wsdl's operation namespace identifier matches a document identifier" do
+        before do
+          client.wsdl.operations[:authenticate][:namespace_identifier] = "tns"
+        end
+
+        it "sets the soap's namespace identifier to the matching operation's namespace identifier" do
+          client.request(:authenticate) { soap.namespace_identifier.should == :tns }
+        end
+
+        it "sets the soap's namespace to the namspace matching the identifier" do
+          client.request(:authenticate) { soap.namespace.should == "http://v1_0.ws.auth.order.example.com/" }
+        end
+
+        it "sets the input tag to result in <tns:authenticate>" do
+          client.request(:authenticate) { soap.input.should == [:tns, :authenticate, {}] }
+        end
+      end
     end
 
     context "with a single argument (String)" do


### PR DESCRIPTION
...ces.

These changes allow you to pass in only a symbol to the `request` method and get an automatic namespace mapping.  This is best shown with an example:

``` xml
<?xml version='1.0' encoding='UTF-8'?>
<wsdl:definitions 
    name="AuthenticationWebServiceImplService"
    targetNamespace="http://v1_0.ws.auth.order.example.com/"
    xmlns:ns1="http://cxf.apache.org/bindings/xformat"
    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
    xmlns:tns="http://v1_0.ws.auth.order.example.com/"
    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
    xmlns:xsd="http://www.w3.org/2001/XMLSchema">

    <wsdl:types>
        <xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://v1_0.ws.auth.order.example.com/" xmlns:tns="http://v1_0.ws.auth.order.example.com/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
            ...
        </xs:schema>
    </wsdl:types>
    <wsdl:message name="authenticate">
        <wsdl:part element="tns:authenticate" name="parameters" />
    </wsdl:message>
    <wsdl:message name="authenticateResponse">
        <wsdl:part element="tns:authenticateResponse" name="parameters" />
    </wsdl:message>
    <wsdl:portType name="AuthenticationWebService">
        <wsdl:operation name="authenticate">
            <wsdl:input message="tns:authenticate" name="authenticate" />
            <wsdl:output message="tns:authenticateResponse" name="authenticateResponse" />
        </wsdl:operation>
    </wsdl:portType>
    <wsdl:binding name="AuthenticationWebServiceImplServiceSoapBinding" type="tns:AuthenticationWebService">
        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
        <wsdl:operation name="authenticate">
            <soap:operation soapAction="" style="document" />
            <wsdl:input name="authenticate">
                <soap:body use="literal" />
            </wsdl:input>
            <wsdl:output name="authenticateResponse">
                <soap:body use="literal" />
            </wsdl:output>
        </wsdl:operation>
    </wsdl:binding>
    <wsdl:service name="AuthenticationWebServiceImplService">
        <wsdl:port binding="tns:AuthenticationWebServiceImplServiceSoapBinding" name="AuthenticationWebServiceImplPort">
            <soap:address location="http://example.com/validation/1.0/AuthenticationService" />
        </wsdl:port>
    </wsdl:service>
</wsdl:definitions>
```

``` ruby
client.request :authenticate
```

This will result in the following soap message.  Note the automatic namespace identifier on the `authenticate` element, as well as the proper namespace inclusion in the document:

``` xml
<env:Envelope 
    xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
    xmlns:tns="http://v1_0.ws.auth.order.example.com/" 
    xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">

    <tns:authenticate>
        <tns:user>username</tns:user>
        <tns:password>password</tns:password>
    </tns:authenticate>
</env:Envelope>
```

This works hand in hand with a `wasabi` PR that I will be making shortly.
