### PR TITLE
Feature: Implements option for Savon to log tidy xml

### DIFF
--- a/lib/savon/soap/request.rb
+++ b/lib/savon/soap/request.rb
@@ -56,13 +56,13 @@ module Savon
       def log_request(url, headers, body)
         Savon.log "SOAP request: #{url}"
         Savon.log headers.map { |key, value| "#{key}: #{value}" }.join(", ")
-        Savon.log body, :filter
+        Savon.log body, :xml
       end
 
       # Logs the SOAP response +code+ and +body+.
       def log_response(code, body)
         Savon.log "SOAP response (status #{code}):"
-        Savon.log body
+        Savon.log body, :xml
       end
 
     end

--- a/spec/savon/savon_spec.rb
+++ b/spec/savon/savon_spec.rb
@@ -48,7 +48,20 @@ describe Savon do
               msg.include?('<ns11:logType>***FILTERED***</ns11:logType>')
             end
 
-            Savon.log(Fixture.response(:list), :filter)
+            Savon.log(Fixture.response(:list), :xml)
+          end
+        end
+
+        context "pretty_xml_logs is set" do
+          it "returns formatted xml with indentation" do
+            Savon.configure { |config| config.pretty_xml_logs = true }
+            Savon.logger.expects(Savon.log_level).with <<-EOF
+<?xml version="1.0"?>
+<hello>
+  <world>Bob</world>
+</hello>
+EOF
+            Savon.log("<?xml version=\"1.0\"?><hello><world>Bob</world></hello>", :xml)
           end
         end
       end

--- a/spec/savon/soap/request_spec.rb
+++ b/spec/savon/soap/request_spec.rb
@@ -61,7 +61,7 @@ describe Savon::SOAP::Request do
       HTTPI.stubs(:post).returns(HTTPI::Response.new 200, {}, "")
 
       Savon.stubs(:log).times(2)
-      Savon.expects(:log).with(soap.to_xml, :filter)
+      Savon.expects(:log).with(soap.to_xml, :xml)
       Savon.stubs(:log).times(2)
 
       soap_request.response


### PR DESCRIPTION
Adds the config option Savon.pretty_xml_logs. When true, all calls to Savon.log(message, :xml) are tidied

Note, also modified the parameter for Savon.log to accept type rather than xml
