### PR TITLE
Clone body for not modifying original object

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -74,6 +74,7 @@ module Savon
       self.soap = SOAP::XML.new
       preconfigure extract_options(args)
       process &block if block
+      soap.body = soap.body.clone if soap.body
       soap.wsse = wsse
 
       response = SOAP::Request.new(http, soap).response


### PR DESCRIPTION
Savon modified original object in case when it contains :attributes!. For example:

``` ruby

module A
  extend self

  def base_body
    @base_data ||= \
      {
        :a => 123,
        :attributes! => {
          :a => {
            :some_attr => 321
          }
        }
      }
  end

end

savon_client.request :some_request do |soap|
  soap.body = A.base_body
end

puts A.base_body
=> { :a => 123 }
```
