### PR TITLE
Allow the SOAP envelope header to be set as a String

### DIFF
--- a/lib/savon/soap/xml.rb
+++ b/lib/savon/soap/xml.rb
@@ -185,7 +185,14 @@ module Savon
 
       # Returns the SOAP header as an XML String.
       def header_for_xml
-        @header_for_xml ||= Gyoku.xml(header) + wsse_header
+        @header_for_xml ||=
+          begin
+            if Hash === header
+              Gyoku.xml(header)
+            else
+              header
+            end + wsse_header
+          end
       end
 
       # Returns the WSSE header or an empty String in case WSSE was not set.

--- a/spec/savon/soap/xml_spec.rb
+++ b/spec/savon/soap/xml_spec.rb
@@ -208,13 +208,22 @@ describe Savon::SOAP::XML do
     end
 
     context "with a SOAP header" do
-      it "should contain the given header" do
-        xml.header = {
-          :token => "secret",
-          :attributes! => { :token => { :xmlns => "http://example.com" } }
-        }
+      context "as a hash" do
+        it "should contain the given header" do
+          xml.header = {
+            :token => "secret",
+            :attributes! => { :token => { :xmlns => "http://example.com" } }
+          }
 
-        xml.to_xml.should include('<env:Header><token xmlns="http://example.com">secret</token></env:Header>')
+          xml.to_xml.should include('<env:Header><token xmlns="http://example.com">secret</token></env:Header>')
+        end
+      end
+      context "as a string" do
+        it "should contain the given header" do
+          xml.header = %{<token xmlns="http://example.com">secret</token>}
+
+          xml.to_xml.should include('<env:Header><token xmlns="http://example.com">secret</token></env:Header>')
+        end
       end
     end
 


### PR DESCRIPTION
Requiring Gyoku for the header adds a layer of unnecessary indirection and overhead, particularly when the data is more natural in its native XML, e.g. when many attributes are involved.
