### PR TITLE
Fix namespaces not being properly added to arrays.

### DIFF
--- a/lib/savon/soap/xml.rb
+++ b/lib/savon/soap/xml.rb
@@ -220,7 +220,7 @@ module Savon
 
       def add_namespaces_to_body(hash, path = [input[1].to_s])
         return unless hash
-        return hash if hash.kind_of?(Array)
+        return hash.map { |value| add_namespaces_to_body(value, path) } if hash.kind_of?(Array)
         return hash.to_s unless hash.kind_of? Hash
 
         hash.inject({}) do |newhash, (key, value)|

--- a/spec/fixtures/wsdl/multiple_namespaces.xml
+++ b/spec/fixtures/wsdl/multiple_namespaces.xml
@@ -19,8 +19,20 @@
                     </s:sequence>
                 </s:complexType>
             </s:element>
+            <s:element name="Lookup">
+              <s:complexType>
+                <s:sequence>
+                  <s:element minOccurs="0" maxOccurs="1" name="articles" type="article:ArrayOfArticle" />
+                </s:sequence>
+              </s:complexType>
+            </s:element>
         </s:schema>
         <s:schema elementFormDefault="qualified" targetNamespace="http://example.com/article">
+            <s:complexType name="ArrayOfArticle">
+              <s:sequence>
+                <s:element minOccurs="0" maxOccurs="unbounded" name="Article" type="article:Article"/>
+              </s:sequence>
+            </s:complexType>
             <s:complexType name="Article">
                 <s:sequence>
                     <s:element minOccurs="0" name="Author" type="s:string"/>
@@ -35,16 +47,35 @@
     <message name="SaveSoapOut">
         <part name="parameters" element="actions:SaveResponse"/>
     </message>
+    <message name="LookupSoapIn">
+        <part name="parameters" element="actions:Lookup"/>
+    </message>
+    <message name="LookupSoapOut">
+        <part name="parameters" element="actions:LookupResponse"/>
+    </message>
     <portType name="ArticleSoap">
         <operation name="Save">
             <input message="actions:SaveSoapIn"/>
             <output message="actions:SaveSoapOut"/>
+        </operation>
+        <operation name="Lookup">
+            <input message="actions:LookupSoapIn"/>
+            <input message="actions:LookupSoapOut"/>
         </operation>
     </portType>
     <binding name="ArticleSoap" type="actions:ArticleSoap">
         <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
         <operation name="Save">
             <soap:operation soapAction="http://example.com/actions.Save" style="document"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="Lookup">
+            <soap:operation soapAction="http://example.com/actions.Lookup" style="document"/>
             <input>
                 <soap:body use="literal"/>
             </input>


### PR DESCRIPTION
When the SOAP request body is passed as a hash, one may specify the
value for a key to be an array of hashes. In this case, each hash
in the array is treated as being contained within a element specified by
the key. The namespace applied to the elements specified within the
array was previously the default namespace. This fix recursively
determines the proper namespaces for these elements.
- Modify lib/savon/soap/xml.rb to recursively determine proper
  namespaces for elements contained within arrays
- Modify spec/fixtures/wsdl/multiple_namespaces.xml to add a new
  operation that properly exhibits the problem
- Modify spec/savon/client_spec.rb to add a new test that exhibits the
  problem
- Modify spec/savon/client_spec.rb to change an old test that failed
  after the change. The failure was not a regression. In this case, the
  same namespace was applied but with a different namespace name.
