### PR TITLE
Add support SOAP 1.2 Action

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -142,11 +142,10 @@ module Savon
       set_soap_input *args
     end
 
-    # Expects an +input+ and sets the +SOAPAction+ HTTP headers.
+    # Expects an +input+ and sets the SOAP action.
     def set_soap_action(input_tag)
-      soap_action = wsdl.soap_action(input_tag.to_sym) if wsdl.document?
-      soap_action ||= Gyoku::XMLKey.create(input_tag).to_sym
-      http.headers["SOAPAction"] = %{"#{soap_action}"}
+      soap.action = wsdl.soap_action(input_tag.to_sym) if wsdl.document?
+      soap.action ||= Gyoku::XMLKey.create(input_tag).to_sym
     end
 
     # Expects a +namespace+, +input+ and +attributes+ and sets the SOAP input.

--- a/lib/savon/soap/request.rb
+++ b/lib/savon/soap/request.rb
@@ -56,6 +56,14 @@ module Savon
         end
 
         http.headers["Content-Type"] = CONTENT_TYPE[soap.version]
+
+        # Set SOAP Action by version
+        if soap.version.egl?(2)
+          http.headers["Content-Type"] << %{;action="#{soap.action}"}
+        else
+          http.headers["SOAPAction"] = %{"#{soap.action}"}
+        end
+
         http.headers["Content-Length"] = soap.to_xml.bytesize.to_s
         http
       end

--- a/lib/savon/soap/xml.rb
+++ b/lib/savon/soap/xml.rb
@@ -57,6 +57,9 @@ module Savon
         @header ||= config.soap_header.nil? ? {} : config.soap_header
       end
 
+      # Accessor for SOAP +action+
+      attr_accessor :action
+
       # Sets the SOAP envelope namespace.
       attr_writer :env_namespace
 


### PR DESCRIPTION
The SOAP 1.1 mandatory SOAPAction HTTP header has been removed in SOAP 1.2. In its place is an optional action parameter on the application/soap+xml media type.
