### PR TITLE
Allow new soap namespace if version number changes

### DIFF
--- a/lib/savon/soap/xml.rb
+++ b/lib/savon/soap/xml.rb
@@ -70,11 +70,19 @@ module Savon
 
       # Returns the +namespaces+. Defaults to a Hash containing the SOAP envelope namespace.
       def namespaces
-        @namespaces ||= begin
-          key = ["xmlns"]
-          key << env_namespace if env_namespace && env_namespace != ""
-          { key.join(":") => SOAP::NAMESPACE[version] }
-        end
+        @namespaces ||= {}
+        @namespaces.merge! soap_env_namespace
+      end
+
+      # Returns the +namespace_key+.
+      def namespace_key
+        key = ["xmlns"]
+        key << env_namespace if env_namespace && env_namespace != ""
+        key.join(":")
+      end
+
+      def soap_env_namespace
+        { namespace_key => SOAP::NAMESPACE[version] }
       end
 
       def namespace_by_uri(uri)

--- a/spec/savon/soap/xml_spec.rb
+++ b/spec/savon/soap/xml_spec.rb
@@ -90,9 +90,16 @@ describe Savon::SOAP::XML do
       xml.namespaces.should == { "xmlns:env" => "http://www.w3.org/2003/05/soap-envelope" }
     end
 
+    it "should contain the correct namespace if the SOAP version changes from 1.1 to 1.2" do
+      xml.version = 1
+      xml.namespaces.should == { "xmlns:env" => "http://schemas.xmlsoap.org/soap/envelope/" }
+      xml.version = 2
+      xml.namespaces.should == { "xmlns:env" => "http://www.w3.org/2003/05/soap-envelope" }
+    end
+
     it "should set the SOAP header" do
       xml.namespaces = { "xmlns:xsd" => "http://www.w3.org/2001/XMLSchema" }
-      xml.namespaces.should == { "xmlns:xsd" => "http://www.w3.org/2001/XMLSchema" }
+      xml.namespaces.should include({ "xmlns:xsd" => "http://www.w3.org/2001/XMLSchema" })
     end
   end
 

--- a/spec/savon/soap_spec.rb
+++ b/spec/savon/soap_spec.rb
@@ -9,7 +9,7 @@ describe Savon::SOAP do
     end
   end
 
-  it "should contain a Rage of supported SOAP versions" do
+  it "should contain a Range of supported SOAP versions" do
     Savon::SOAP::VERSIONS.should == (1..2)
   end
 


### PR DESCRIPTION
The correct SOAP namespace wasn't being set if the SOAP version changed.
