### PR TITLE
Forward log_level and logger to HTTPI

### DIFF
--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -134,12 +134,13 @@ module Savon
 
     # Whether or not to log.
     def log(log)
-      HTTPI.log = log
+      HTTPI    .log  = log
       @options[:log] = log
     end
 
     # The logger to use. Defaults to a Savon::Logger instance.
     def logger(logger)
+      HTTPI    .logger  = logger
       @options[:logger] = logger
     end
 
@@ -152,6 +153,7 @@ module Savon
                              "Expected one of: #{levels.keys.inspect}"
       end
 
+      HTTPI        .log_level = level
       @options[:logger].level = levels[level]
     end
 


### PR DESCRIPTION
Only the log value was forwarded to HTTPI.
We also want to forward the logger and the log_level to have a consistent state between HTTPI and Savon.
