### PR TITLE
Change gemspec to not rely on the presence of git and the git repository

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -32,6 +32,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha", "~> 0.11"
   s.add_development_dependency "json",  "~> 1.7"
 
-  s.files = `git ls-files`.split("\n")
+    
+  ignores = File.readlines('.gitignore').grep(/\S+/).map {|s| s.chomp }
+  dotfiles = [ '.gitignore', '.rspec', '.travis.yml', '.yardopts' ]
+  s.files = (Dir["**/*"].reject { |f| File.directory?(f) || ignores.any? { |i| File.fnmatch(i, f) } } + dotfiles).sort
+
   s.require_path = "lib"
 end


### PR DESCRIPTION
I'm hoping you will accept this pull request, or at least do something similar. Although having `git ls-files` is fairly common these days in gem specifications, its actually bad practice because it makes the gem dependent on the existence of git and the git repository. Not all deployment systems have git installed, even though one might want to use the latest git master of a particular gem.

Also, a new feature in the latest version of Bundler (1.2.x) enables "bundle package --all" to unpack git repositories specified in the Gemfile into vendor/cache, also removing the git repository (.git directory). This allows one to deploy gems for the latest master of a particular git repository without having to checkout the repository when deploying to production. Savon is currently broken when using this deployment methodology.

For example, in my Gemfile I have

``` ruby
gem 'savon', :git => 'git://github.com/savonrb/savon.git'
```

I run something like the following in my development environment

```
bundle package --all

Using savon (2.0.3) from git://github.com/savonrb/savon.git (at /Users/courtland/myapp/vendor/cache/savon-6de06caf367e) 

```

In my production environment I run

```
bundle install --deployment
fatal: Not a git repository (or any of the parent directories): .git
```

The "fatal: Not a git..." error comes from savon.

Thanks.
