### PR TITLE
Convert the path to snakecase for each call

### DIFF
--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -62,7 +62,15 @@ module Savon
         @internal_namespace_count += 1
       end
 
-      [path, identifier]
+      # The paths should be in snake case to match @operation_name.  We iterate
+      # through each item in path and convert to snake case and return the new
+      # array.
+      new_path = []
+      path.each do |p|
+        new_path << p.snakecase
+      end
+
+      [new_path, identifier]
     end
 
     def namespaces_with_globals


### PR DESCRIPTION
Convert the path to each operation to snakecase in `builder#use_namespace`.  

It appears that the format of these strings were always lower camel case, whereas `@operation_name` is in snakecase.  This would result in no matches being found when there were multiple namespaces.  Converting the string to snakecase (hopefully) resolves this issue.

Related to: [Issue #384](//github.com/savonrb/savon/issues/384)

[![Build Status](https://travis-ci.org/savonrb/savon.png?branch=issue-384-convert_request_keys_to)](https://travis-ci.org/savonrb/savon)
