### PR TITLE
SOAPFault wrongly assumes that the hash keys will be symbols

### DIFF
--- a/spec/savon/soap_fault_spec.rb
+++ b/spec/savon/soap_fault_spec.rb
@@ -3,10 +3,13 @@ require "spec_helper"
 describe Savon::SOAPFault do
   let(:soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault)), nori }
   let(:soap_fault2) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault12)), nori }
+  let(:soap_fault_nc) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault)), nori_no_convert }
+  let(:soap_fault_nc2) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault12)), nori_no_convert }
   let(:another_soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:another_soap_fault)), nori }
   let(:no_fault) { Savon::SOAPFault.new new_response, nori }
 
   let(:nori) { Nori.new(:strip_namespaces => true, :convert_tags_to => lambda { |tag| tag.snakecase.to_sym }) }
+  let(:nori_no_convert) { Nori.new(:strip_namespaces => true, :convert_tags_to => nil) }
 
   it "inherits from Savon::Error" do
     expect(Savon::SOAPFault.ancestors).to include(Savon::Error)
@@ -52,6 +55,14 @@ describe Savon::SOAPFault do
       it "returns a SOAP fault message (with different namespaces)" do
         expect(another_soap_fault.send method).to eq("(ERR_NO_SESSION) Wrong session message")
       end
+
+      it "works even if the keys are different in a SOAP 1.1 fault message" do
+        soap_fault_nc.send method
+      end
+
+      it "works even if the keys are different in a SOAP 1.2 fault message" do
+        soap_fault_nc2.send method
+      end
     end
   end
 
@@ -81,6 +92,10 @@ describe Savon::SOAPFault do
       }
 
       expect(soap_fault2.to_hash).to eq(expected)
+    end
+
+    it "works even if the keys are different" do
+      soap_fault_nc2.to_hash
     end
   end
 


### PR DESCRIPTION
First of all, thank you for making this excellent gem.

I like to use the `convert_tags_to: nil` option with Savon so that it will work with some legacy code that requires the response hash keys to be CamelCase strings.  However, the SOAPFault class assumes the response hash keys will be snake_case symbols, which is the default.  As a result, if a SOAP fault occurs and the error handling code tries to call `to_s` or `to_hash` on the SOAPFault exception we get another exception (`undefined method '[]' for nil:NilClass`).  This is bad because it makes it hard for me to see the actual error message returned by the server.  Also, developers probably don't expect that calling `to_s` will raise another exception.

This pull request contains some new rspec examples in `soap_fault_spec.rb` that demonstrate the problem.

How do you think we should solve this?  I see two reasonable options:
1. Add a new method to Nori that is like `parse`, but ignores the two special options that affect keys (`strip_namespaces` and `convert_tags_to`).  Use this method in the SOAPFault class so that that the keys in the hash will be predictable.
2. Add a new method to Nori that takes a string tag name as an input, and returns the expected hash key as an output.  That code already exists in the initialize method of `Nori::XMLUtilityMode`. Use this method in the SOAPFault class so that we can be sure to access the right hash key, not matter what it is.

I think option 1 is cleaner, but option 2 might be better because we can then use it to make `Savon::Response#body` and `Savon::Response#header` work properly.  ( However I see from [here](https://github.com/savonrb/savon/blob/d813e453ee8fc361b705a57d787ed862a8c19530/spec/savon/options_spec.rb#L511-L512) that the you have already considered that and decided against it. )

Thanks!
