### PR TITLE
Update lib/savon/builder.rb

### DIFF
--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -93,6 +93,8 @@ module Savon
     def namespaced_message_tag
       if @used_namespaces[[@operation_name.to_s]]
         [@used_namespaces[[@operation_name.to_s]], message_tag, message_attributes]
+      elsif namespace_identifier.eql?(:none)
+        [message_tag, message_attributes]
       else
         [namespace_identifier, message_tag, message_attributes]
       end


### PR DESCRIPTION
Ability to disable namespace identifier. This is necessary for certain services like Zimbra's Soap API. 

This code change allows for Savon.client(namespace_identifier: :none)
