### PR TITLE
NTLM support

### DIFF
--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -219,6 +219,11 @@ module Savon
       @options[:digest_auth] = credentials.flatten
     end
 
+    # NTLM auth credentials.
+    def ntlm(*credentials)
+      @options[:ntlm] = credentials.flatten
+    end
+
     # WSSE auth credentials for Akami.
     def wsse_auth(*credentials)
       @options[:wsse_auth] = credentials.flatten

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -35,8 +35,9 @@ module Savon
     end
 
     def configure_auth
-      @http_request.auth.basic(*@globals[:basic_auth])   if @globals.include? :basic_auth
-      @http_request.auth.digest(*@globals[:digest_auth]) if @globals.include? :digest_auth
+      @http_request.auth.basic(*@globals[:basic_auth])    if @globals.include? :basic_auth
+      @http_request.auth.digest(*@globals[:digest_auth])  if @globals.include? :digest_auth
+      @http_request.auth.ntlm(*@globals[:ntlm])           if @globals.include?(:ntlm)
     end
 
   end

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -387,6 +387,18 @@ describe "Options" do
     end
   end
 
+  context "global :ntlm" do
+    it "sets the ntlm credentials to use" do
+      credentials = ["admin", "secret"]
+      client = new_client(:endpoint => @server.url, :ntlm => credentials)
+
+      # TODO: find a way to integration test this. including an entire ntlm server implementation seems a bit over the top though.
+      HTTPI::Auth::Config.any_instance.expects(:ntlm).with(credentials)
+
+      response = client.call(:authenticate)
+    end
+  end
+
   context "global :filters" do
     it "filters a list of XML tags from logged SOAP messages" do
       client = new_client(:endpoint => @server.url(:repeat), :log => true)

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -207,6 +207,20 @@ describe Savon::WSDLRequest do
         new_wsdl_request.build
       end
     end
+
+    describe "ntlm auth" do
+      it "is set when specified" do
+        globals.ntlm("han", "super-secret")
+        http_request.auth.expects(:ntlm).with("han", "super-secret")
+
+        new_wsdl_request.build
+      end
+
+      it "is not set otherwise" do
+        http_request.auth.expects(:ntlm).never
+        new_wsdl_request.build
+      end
+    end
   end
 
 end
@@ -457,6 +471,20 @@ describe Savon::SOAPRequest do
 
       it "is not set otherwise" do
         http_request.auth.expects(:digest).never
+        new_soap_request.build
+      end
+    end
+
+    describe "ntlm auth" do
+      it "is set when specified" do
+        globals.ntlm("han", "super-secret")
+        http_request.auth.expects(:ntlm).with("han", "super-secret")
+
+        new_soap_request.build
+      end
+
+      it "is not set otherwise" do
+        http_request.auth.expects(:ntlm).never
         new_soap_request.build
       end
     end


### PR DESCRIPTION
https://github.com/savonrb/httpi/pull/80 brings in up-to-date NTLM support for HTTPI, so I figured I'd take a stab at putting in the appropriate hooks to do NTLM auth in a Savon client too.

This probably needs to wait for a new version of HTTPI to be released, however, so the dependency version can be bumped too. Happy to make that change and add it to this PR when the new version is out.
