### PR TITLE
Add a #servicename method hooked on Wasabi::Document#servicename.

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -36,6 +36,11 @@ module Savon
       operation(operation_name).call(locals, &block)
     end
 
+    def servicename
+      raise_missing_wsdl_error! unless @wsdl.document?
+      @wsdl.servicename
+    end
+
     private
 
     def set_globals(globals, block)
@@ -48,9 +53,10 @@ module Savon
     def build_wsdl_document
       @wsdl = Wasabi::Document.new
 
-      @wsdl.document  = @globals[:wsdl]      if @globals.include? :wsdl
-      @wsdl.endpoint  = @globals[:endpoint]  if @globals.include? :endpoint
-      @wsdl.namespace = @globals[:namespace] if @globals.include? :namespace
+      @wsdl.document    = @globals[:wsdl]        if @globals.include? :wsdl
+      @wsdl.endpoint    = @globals[:endpoint]    if @globals.include? :endpoint
+      @wsdl.namespace   = @globals[:namespace]   if @globals.include? :namespace
+      @wsdl.servicename = @globals[:servicename] if @globals.include? :servicename
 
       @wsdl.request = WSDLRequest.new(@globals).build
     end

--- a/spec/savon/client_spec.rb
+++ b/spec/savon/client_spec.rb
@@ -64,6 +64,13 @@ describe Savon::Client do
     end
   end
 
+  describe "#servicename" do
+    it "returns the 'name' attribute" do
+      servicename = new_client.servicename
+      expect(servicename).to eq('AuthenticationWebServiceImplService')
+    end
+  end
+
   describe "#operations" do
     it "returns all operation names" do
       operations = new_client.operations


### PR DESCRIPTION
This is the link between Savon and Wasabi (see https://github.com/savonrb/wasabi/pull/22).
Can be overridden by global options.
