### PR TITLE
Remove ruby 1.9 hash syntax in spec

### DIFF
--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -38,7 +38,7 @@ describe "Options" do
 
     it "ignores namespace identifier if it is nil" do
       client = new_client(:endpoint => @server.url(:repeat), :namespace_identifier => nil)
-      response = client.call(:authenticate, message: {user: 'foo'})
+      response = client.call(:authenticate, :message => {:user => 'foo'})
 
       expect(response.http.body).to include('xmlns="http://v1_0.ws.auth.order.example.com/"')
       expect(response.http.body).to include("<authenticate><user>foo</user></authenticate>")


### PR DESCRIPTION
Required to prevent spec from blowing up under REE
