### PR TITLE
allow code to rescue and ignore Savon::Error's and still have mocks trigger test failures

### DIFF
--- a/lib/savon/mock.rb
+++ b/lib/savon/mock.rb
@@ -1,5 +1,5 @@
 module Savon
-  class ExpectationError < Error; end
+  class ExpectationError < ::Exception; end
 end
 
 require "savon/mock/expectation"

--- a/spec/savon/mock_spec.rb
+++ b/spec/savon/mock_spec.rb
@@ -114,6 +114,22 @@ describe "Savon's mock interface" do
                                               "  with this message: #{message.inspect}")
   end
 
+  it "allows code to rescue Savon::Error and still report test failures" do
+    message = { :username => "luke" }
+    savon.expects(:find_user).with(:message => message).returns("<fixture/>")
+
+    expect do
+      begin
+        new_client.call(:find_user)
+      rescue Savon::Error => e
+        puts "any real error (e.g. SOAP fault or HTTP error) is OK in the big picture, move on"
+      end
+    end.to raise_error(Savon::ExpectationError, "Expected a request to the :find_user operation\n" \
+                                              "  with this message: #{message.inspect}\n" \
+                                              "Received a request to the :find_user operation\n" \
+                                              "  with no message.")
+  end
+
   def new_client(globals = {})
     defaults = {
       :endpoint  => "http://example.com",


### PR DESCRIPTION
see #428
