### PR TITLE
Encode message in encoding specified in globals

### DIFF
--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -34,15 +34,14 @@ module Savon
 
     def to_s
       return @locals[:xml] if @locals.include? :xml
-      
-      
+
       string = tag(builder, :Envelope, namespaces_with_globals) do |xml|
         tag(xml, :Header) { xml << header.to_s } unless header.empty?
         tag(xml, :Body)   { xml.tag!(*namespaced_message_tag) { xml << message.to_s } }
       end
-      
+
       if @globals[:encoding] && @globals[:encode_message]
-        string.encode!(@globals[:encoding])
+        string.encode!(@globals[:encoding], undef: :replace, replace:'')
       end
       string
     end

--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -41,9 +41,10 @@ module Savon
         tag(xml, :Body)   { xml.tag!(*namespaced_message_tag) { xml << message.to_s } }
       end
       
-      if @globals[:encoding]
+      if @globals[:encoding] && @globals[:encode_message]
         string.encode!(@globals[:encoding])
       end
+      string
     end
 
     private

--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -34,10 +34,15 @@ module Savon
 
     def to_s
       return @locals[:xml] if @locals.include? :xml
-
-      tag(builder, :Envelope, namespaces_with_globals) do |xml|
+      
+      
+      string = tag(builder, :Envelope, namespaces_with_globals) do |xml|
         tag(xml, :Header) { xml << header.to_s } unless header.empty?
         tag(xml, :Body)   { xml.tag!(*namespaced_message_tag) { xml << message.to_s } }
+      end
+      
+      if @globals[:encoding]
+        string.encode!(@globals[:encoding])
       end
     end
 

--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -45,6 +45,7 @@ module Savon
 
       defaults = {
         :encoding                  => "UTF-8",
+        :encode_message            => false,
         :soap_version              => 1,
         :namespaces                => {},
         :logger                    => Logger.new($stdout),
@@ -116,6 +117,12 @@ module Savon
     def encoding(encoding)
       @options[:encoding] = encoding
     end
+    
+    # Whether to encode messages or not. Defaults to false
+    def encode_message(encode_message)
+      @options[:encode_message] = encode_message
+    end
+    
 
     # The global SOAP header. Expected to be a Hash.
     def soap_header(header)

--- a/spec/savon/builder_spec.rb
+++ b/spec/savon/builder_spec.rb
@@ -90,7 +90,15 @@ describe Savon::Builder do
       expect(builder.to_s.encoding.name).to eq "ISO-8859-1"
       expect(builder.to_s).to include("<username>lüke</username>".encode("ISO-8859-1"))
     end
-    
+
+    it "ignores characters not found in the target encoding" do
+      globals[:encoding] = "ISO-8859-1"
+      globals[:encode_message] = true
+      locals[:message] = { :username => "lüke\u2122", :password => "secret" }
+      expect(builder.to_s.encoding.name).to eq "ISO-8859-1"
+      expect(builder.to_s).to include("<username>lüke</username>".encode("ISO-8859-1"))
+    end
+
     context "with encode_message unset" do
       before :each do
         globals[:encoding] = "ISO-8859-1"

--- a/spec/savon/builder_spec.rb
+++ b/spec/savon/builder_spec.rb
@@ -82,15 +82,42 @@ describe Savon::Builder do
 
       expect(builder.to_s).to include("<tns:username>luke</tns:username>")
     end
-    
-    it "converts the message to the configured encoding" do
+
+    it "converts the message to the configured encoding if encode_message" do
       globals[:encoding] = "ISO-8859-1"
+      globals[:encode_message] = true
       locals[:message] = { :username => "lüke", :password => "secret" }
       expect(builder.to_s.encoding.name).to eq "ISO-8859-1"
       expect(builder.to_s).to include("<username>lüke</username>".encode("ISO-8859-1"))
-      
+    end
+    
+    context "with encode_message unset" do
+      before :each do
+        globals[:encoding] = "ISO-8859-1"
+        locals[:message] = { :username => "lüke", :password => "secret" }
+      end
+      it "does not convert the message" do
+        expect(builder.to_s).to include("<username>lüke</username>")
+      end
+      it "keeps the encoding of utf-8" do
+        expect(builder.to_s.encoding.name).to eq "UTF-8"
+      end
     end
 
+    context "with encode_message set to false" do
+      before :each do
+        globals[:encoding] = "ISO-8859-1"
+        globals[:encode_message] = false
+        locals[:message] = { :username => "lüke", :password => "secret" }
+      end
+
+      it "does not convert the message to the configured encoding" do
+        expect(builder.to_s).to include("<username>lüke</username>")
+      end
+      it "keeps the encoding of utf-8" do
+        expect(builder.to_s.encoding.name).to eq "UTF-8"
+      end
+    end
   end
 
 end

--- a/spec/savon/builder_spec.rb
+++ b/spec/savon/builder_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 
 describe Savon::Builder do
@@ -80,6 +81,14 @@ describe Savon::Builder do
       wsdl.element_form_default = :qualified
 
       expect(builder.to_s).to include("<tns:username>luke</tns:username>")
+    end
+    
+    it "converts the message to the configured encoding" do
+      globals[:encoding] = "ISO-8859-1"
+      locals[:message] = { :username => "lüke", :password => "secret" }
+      expect(builder.to_s.encoding.name).to eq "ISO-8859-1"
+      expect(builder.to_s).to include("<username>lüke</username>".encode("ISO-8859-1"))
+      
     end
 
   end

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -121,6 +121,18 @@ describe "Options" do
       expect(content_type).to eq("text/xml;charset=ISO-8859-1")
     end
   end
+  
+  context "global :encode_message" do
+    it "allows to switch on the encoding of messages" do
+      client = new_client(:encode_message => :true)
+      expect(client.globals[:encode_message]).to be_true
+    end
+
+    it "disables the encoding of messages by default" do
+      client = new_client()
+      expect(client.globals[:encode_message]).to be_false
+    end
+  end
 
   context "global :soap_header" do
     it "accepts a Hash of SOAP header information" do


### PR DESCRIPTION
Currently the encoding is only set on the request, but the message isn't actually converted. This leads to errors with german umlauts (For example in addressdata).
