### PR TITLE
Allow Savon mocks to receive any message. Closes #402

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Feature: [#402](https://github.com/savonrb/savon/issues/402) Makes it possible to create mocks that don't care about the message sent: `savon.expects(:authenticate).with(message: :any)`.
+
 * Feature: [#424](https://github.com/savonrb/savon/issues/424) Adds support for multipart responses
   through the updated [savon-multipart](https://github.com/savonrb/savon-multipart) gem. You can now
   specify the `multipart: true` either as a global or local option. Please make sure you have the

--- a/docs/version2.md
+++ b/docs/version2.md
@@ -1080,7 +1080,7 @@ but can easily be changed to support any global and or local option along with t
 This is possible because Savon mocks the request as late as possible to ensure everything works as expected
 in your integration tests.
 
-If you're trying to "stub" a request, you can simply leave out the `#with` method, but you need to call the
+If you're trying to "stub" a request, you can pass `message: any` to the `#with` method to accept any message. You still need to call the
 `#returns` method to return a response that Savon can work with.
 
 ``` ruby

--- a/lib/savon/mock/expectation.rb
+++ b/lib/savon/mock/expectation.rb
@@ -54,6 +54,7 @@ module Savon
     end
 
     def verify_message!
+      return if @expected[:message] == :any
       unless @expected[:message] == @actual[:message]
         expected_message = "  with this message: #{@expected[:message].inspect}" if @expected[:message]
         expected_message ||= "  with no message."

--- a/spec/savon/mock_spec.rb
+++ b/spec/savon/mock_spec.rb
@@ -114,6 +114,20 @@ describe "Savon's mock interface" do
                                               "  with this message: #{message.inspect}")
   end
 
+  it "does not fail when any message is expected and an actual message" do
+    savon.expects(:find_user).with(:message => :any).returns("<fixture/>")
+    message = { :username => "luke" }
+
+    expect { new_client.call(:find_user, :message => message) }.to_not raise_error
+  end
+
+  it "does not fail when any message is expected and no actual message" do
+    savon.expects(:find_user).with(:message => :any).returns("<fixture/>")
+
+    expect { new_client.call(:find_user) }.to_not raise_error
+  end
+
+
   it "allows code to rescue Savon::Error and still report test failures" do
     message = { :username => "luke" }
     savon.expects(:find_user).with(:message => message).returns("<fixture/>")


### PR DESCRIPTION
Previously, there was no way to create a mock without expectation of the
specific message to be sent to the SOAP action.

Contrary to the documentation, leaving out the `with` method would result in an
expectation that the action be called without a message.

This change adds a special case to `#with` so that calling `#with(message: :any)`
ends up setting an expectation that the SOAP action be called, but
without caring about the actual message sent to the action.

This way the following will pass:

```
savon.expects(:authenticate).with(message: :any)
client.call(:authenticate)
client.call(:authenticate, message: { username: "luke", password: "secret" })
```
