### PR TITLE
Missing getters on Savon::Response soap_fault/soap_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* Fix: [#450](https://github.com/savonrb/savon/pull/450) Add back attr_readers Response#soap_fault and Response#http_error
+
 * Feature: [#402](https://github.com/savonrb/savon/issues/402) Makes it possible to create mocks that don't care about the message sent: `savon.expects(:authenticate).with(message: :any)`.
 
 * Feature: [#424](https://github.com/savonrb/savon/issues/424) Adds support for multipart responses

--- a/lib/savon/response.rb
+++ b/lib/savon/response.rb
@@ -10,10 +10,11 @@ module Savon
       @globals = globals
       @locals  = locals
 
+      build_soap_and_http_errors!
       raise_soap_and_http_errors! if @globals[:raise_errors]
     end
 
-    attr_reader :http, :globals, :locals
+    attr_reader :http, :globals, :locals, :soap_fault, :http_error
 
     def success?
       !soap_fault? && !http_error?
@@ -66,9 +67,14 @@ module Savon
 
     private
 
+    def build_soap_and_http_errors!
+      @soap_fault = SOAPFault.new(@http, nori) if soap_fault?
+      @http_error = HTTPError.new(@http) if http_error?
+    end
+
     def raise_soap_and_http_errors!
-      raise SOAPFault.new(@http, nori) if soap_fault?
-      raise HTTPError.new(@http) if http_error?
+      raise soap_fault if soap_fault?
+      raise http_error if http_error?
     end
 
     def raise_invalid_response_error!

--- a/spec/savon/response_spec.rb
+++ b/spec/savon/response_spec.rb
@@ -53,6 +53,18 @@ describe Savon::Response do
     end
   end
 
+  describe "#soap_fault" do
+    before { globals[:raise_errors] = false }
+
+    it "should return nil in case the response seems to be ok" do
+      soap_response.soap_fault.should be_nil
+    end
+
+    it "should return a SOAPFault in case of a SOAP fault" do
+      soap_fault_response.soap_fault.should be_a(Savon::SOAPFault)
+    end
+  end
+
   describe "#http_error?" do
     before { globals[:raise_errors] = false }
 
@@ -62,6 +74,18 @@ describe Savon::Response do
 
     it "should return true in case of an HTTP error" do
       soap_response(:code => 500).http_error?.should be_true
+    end
+  end
+
+  describe "#http_error" do
+    before { globals[:raise_errors] = false }
+
+    it "should return nil in case the response seems to be ok" do
+      soap_response.http_error.should be_nil
+    end
+
+    it "should return a HTTPError in case of an HTTP error" do
+      soap_response(:code => 500).http_error.should be_a(Savon::HTTPError)
     end
   end
 


### PR DESCRIPTION
`Savon::Response` is missing getters `soap_fault` and `soap_error` to access these exceptions when using `:raise_errors      =>  false,`.

Please let me know if I overlooked something. If not, I will prepare a pull request if you are busy.
