### PR TITLE
Fix #487: Allow nokogiri 1.6 with warnings for ruby 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ or add it to your Gemfile like this:
 gem 'savon', '~> 2.3.0'
 ```
 
+Savon versions >= 2.3 depend on a recent version of Nokogiri. If you are
+installing Savon for Ruby 1.8, you will need to install a 1.8-compatible
+version of Nokogiri manually, or specify the latest compatible version
+in your Gemfile:
+
+```ruby
+gem 'nokogiri', '>= 1.4', '< 1.6'
+```
 
 ## Usage example
 

--- a/savon.gemspec
+++ b/savon.gemspec
@@ -16,6 +16,13 @@ Gem::Specification.new do |s|
   s.rubyforge_project = s.name
   s.license = 'MIT'
 
+  s.post_install_message = %q{
+  When using Savon for Ruby 1.8, be sure to lock these dependencies your
+  Gemfile, or else install a compatible version manually:
+
+  gem "nokogiri", ">= 1.4", "< 1.6"
+  }
+
   s.add_dependency "nori",     "~> 2.3.0"
   s.add_dependency "httpi",    "~> 2.1.0"
   s.add_dependency "wasabi",   "~> 3.2.0"
@@ -23,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency "gyoku",    "~> 1.1.0"
 
   s.add_dependency "builder",  ">= 2.1.2"
-  s.add_dependency "nokogiri", ">= 1.4.0", "< 1.6"
+  s.add_dependency "nokogiri", ">= 1.4.0"
 
   s.add_development_dependency "rack"
   s.add_development_dependency "puma",  "2.0.0.b4"


### PR DESCRIPTION
I added documentation and a `post_install_message` to the gemspec.

Fixes #487
