### PR TITLE
Add types to first level nodes

### DIFF
--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -133,7 +133,7 @@ module Savon
       message_components = nil
       message_components = @wsdl.parser.instance_variable_get(:@messages)["#{LOWER_CAMELCASE.call(@operation_name.to_s)}Request"] unless @wsdl.document.nil?
       message_components.children.each do |t|
-        types[t['name'].snakecase.to_sym] = { 'xsi:type' => t['type']} if t['name'].present?
+        types[t['name'].snakecase.to_sym] = { 'xsi:type' => t['type']} unless t['name'].nil?
       end unless (message_components.nil?)
       msg = (@locals[:message].nil? or types.empty?) ? @locals[:message] : @locals[:message].merge(:attributes! => types)
       Message.new(@operation_name, namespace_identifier, @types, @used_namespaces, msg,

--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -133,7 +133,18 @@ module Savon
       message_components = nil
       message_components = @wsdl.parser.instance_variable_get(:@messages)["#{LOWER_CAMELCASE.call(@operation_name.to_s)}Request"] unless @wsdl.document.nil?
       message_components.children.each do |t|
-        types[t['name'].snakecase.to_sym] = { 'xsi:type' => t['type']} unless t['name'].nil?
+        unless t['name'].nil?
+          type = t['name'].snakecase.to_sym
+          types[type] = {'xsi:type' => t['type']}
+          typeC = CAMELCASE.call(t['name'])
+          unless @wsdl.parser.types[typeC].nil?
+            first_level_attributes = {}
+            @wsdl.parser.types[typeC].each do |element, attr|
+              first_level_attributes[element.snakecase.to_sym] = {'xsi:type'=> attr[:type]} unless element.is_a?(Symbol)
+            end
+            @locals[:message][type].merge!(:attributes! => first_level_attributes) unless (@locals[:message].nil? or @locals[:message][type].nil?)
+          end
+        end
       end unless (message_components.nil?)
       msg = (@locals[:message].nil? or types.empty?) ? @locals[:message] : @locals[:message].merge(:attributes! => types)
       Message.new(@operation_name, namespace_identifier, @types, @used_namespaces, msg,

--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -126,7 +126,11 @@ module Savon
     def message
       element_form_default = @globals[:element_form_default] || @wsdl.element_form_default
       # TODO: clean this up! [dh, 2012-12-17]
-      Message.new(@operation_name, namespace_identifier, @types, @used_namespaces, @locals[:message],
+      types = {}
+      @wsdl.parser.instance_variable_get(:@messages)["#{@operation_name.to_s.camelcase(:lower)}Request"].children.each do |t|
+        types[t['name'].snakecase.to_sym] = { 'xsi:type' => t['type']} if t['name'].present?
+      end
+      Message.new(@operation_name, namespace_identifier, @types, @used_namespaces, @locals[:message].merge(:attributes! => types),
                   element_form_default, @globals[:convert_request_keys_to])
     end
 


### PR DESCRIPTION
The types of first level nodes are present in the WSDL's message section for the request. Those can be added from there. I am not sure why wasabi document does not have an attribute accessor for @messages. I could have avoided the call to instance_variable_get. If you agree I can make that change in another pull request to wasabi. Adding of types to inner nodes will need me to check in @types. Before I try that I wanted to understand the reason of keeping arrays as keys for @types rather than having nested hash structure. Suggestions are welcome.
