### PR TITLE
Version limit for nokogiri on ruby > 1.8 removed

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -23,7 +23,13 @@ Gem::Specification.new do |s|
   s.add_dependency "gyoku",    "~> 1.1.0"
 
   s.add_dependency "builder",  ">= 2.1.2"
-  s.add_dependency "nokogiri", ">= 1.4.0", "< 1.6"
+
+  if RUBY_VERSION[0,3] == "1.8"
+    # nokogiri 1.6 dropped support for ruby 1.8
+    s.add_dependency "nokogiri", ">= 1.4.0", "< 1.6"
+  else
+    s.add_dependency "nokogiri", ">= 1.4.0"
+  end
 
   s.add_development_dependency "rack"
   s.add_development_dependency "puma",  "2.0.0.b4"


### PR DESCRIPTION
The current version constraint makes it impossible to use more recent version of Nokogiri on Ruby 1.9 and 2.0.
