### PR TITLE
Added build operation response method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 * Fix: [#509](https://github.com/savonrb/savon/issues/402) Attributes now added to array of hashes.
 
+* Added methods to the Operation class to build a response envelope and return an example response.
+
 ## master
 
 * Fix: [#450](https://github.com/savonrb/savon/pull/450) Add back attr_readers Response#soap_fault and Response#http_error

--- a/lib/savon/envelope.rb
+++ b/lib/savon/envelope.rb
@@ -6,7 +6,7 @@ class Savon
 
     NSID = 'lol'
 
-    def initialize(operation, header, body)
+    def initialize(operation, header, body, use_output = false)
       @logger = Logging.logger[self]
 
       @operation = operation
@@ -15,6 +15,7 @@ class Savon
 
       @nsid_counter = -1
       @namespaces = {}
+      @use_output = use_output
     end
 
     def register_namespace(namespace)
@@ -34,12 +35,16 @@ class Savon
 
     def build_header
       return "" if @header.empty?
-      Message.new(self, @operation.input.header_parts).build(@header)
+
+      header_parts = (@use_output ? @operation.output : @operation.input).header_parts
+      Message.new(self, header_parts).build(@header)
     end
 
     def build_body
       return "" if @body.empty?
-      body = Message.new(self, @operation.input.body_parts).build(@body)
+
+      parts = (@use_output ? @operation.output : @operation.input).body_parts
+      body = Message.new(self, parts).build(@body)
 
       if rpc_call?
         build_rpc_wrapper(body)

--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -60,6 +60,9 @@ class Savon
     # Public: Sets the request body Hash.
     attr_accessor :body
 
+    # Public: Sets the response body and header
+    attr_accessor :response_body, :response_header
+
     # Public: Create an example request body Hash.
     def example_body
       ExampleMessage.build(@operation.input.body_parts)
@@ -75,10 +78,18 @@ class Savon
       Envelope.new(@operation, header, body).to_s
     end
 
+    def example_response_body
+      ExampleMessage.build(@operation.output.body_parts)
+    end
+
     # Public: Call the operation.
     def call
       raw_response = @http.post(endpoint, http_headers, build)
       Response.new(raw_response)
+    end
+
+    def build_response
+      Envelope.new(@operation, response_header, response_body, true).to_s
     end
 
     # Public: Returns the input style for this operation.

--- a/lib/savon/wsdl/binding_operation.rb
+++ b/lib/savon/wsdl/binding_operation.rb
@@ -23,44 +23,63 @@ class Savon
 
       # TODO: maybe use proper classes to clean this up.
       def input_headers
-        return @input_headers if @input_headers
+        return get_header('input')
+      end
+
+      def output_headers
+        return get_header('output')
+      end
+
+
+      # TODO: maybe use proper classes to clean this up.
+      def input_body
+        return get_body('input')
+      end
+
+      def output_body
+        return get_body('output')
+      end
+
+      def get_header(input_or_output)
+        headers = input_or_output == "output" ? @input_headers : @output_headers
+        return headers if headers
         input_headers = []
 
-        if header_nodes = find_input_child_nodes('header')
+        if header_nodes = find_child_nodes('header', input_or_output)
           header_nodes.each do |header_node|
             input_headers << {
-              encoding_style: header_node['encodingStyle'],
-              namespace:      header_node['namespace'],
-              use:            header_node['use'],
-              message:        header_node['message'],
-              part:           header_node['part']
+                encoding_style: header_node['encodingStyle'],
+                namespace: header_node['namespace'],
+                use: header_node['use'],
+                message: header_node['message'],
+                part: header_node['part']
             }
           end
         end
 
-        @input_headers = input_headers
+        input_headers
       end
 
-      # TODO: maybe use proper classes to clean this up.
-      def input_body
-        return @input_body if @input_body
+      def get_body(input_or_output)
+        body = input_or_output == "output" ? @output_body : @input_body
+        return body if body
         input_body = {}
 
-        if body_node = find_input_child_nodes('body').first
+        if body_node = find_child_nodes('body', input_or_output).first
           input_body = {
-            encoding_style: body_node['encodingStyle'],
-            namespace:      body_node['namespace'],
-            use:            body_node['use']
+              encoding_style: body_node['encodingStyle'],
+              namespace: body_node['namespace'],
+              use: body_node['use']
           }
         end
 
-        @input_body = input_body
+        input_body
       end
 
       private
 
-      def find_input_child_nodes(child_name)
-        input_node = @operation_node.element_children.find { |node| node.name == 'input' }
+      def find_child_nodes(child_name, type)
+        input_node = @operation_node.element_children.find { |node| node.name == type }
         return unless input_node
 
         input_node.element_children.select { |node| node.name == child_name }

--- a/spec/savon/operation/build_response_spec.rb
+++ b/spec/savon/operation/build_response_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe Savon::Operation do
+
+  let(:add_logins) {
+    client = Savon.new fixture('wsdl/bronto')
+
+    service_name = :BrontoSoapApiImplService
+    port_name = :BrontoSoapApiImplPort
+
+    client.operation(service_name, port_name, :addLogins)
+  }
+
+  describe "#build_response" do
+    it "expects an Array of complex types as an Array of Hashes" do
+      add_logins.response_body = {
+          :addLoginsResponse => {
+              :return => {
+                  :errors => [123, 456],
+                  :results => [
+                      {:id => 123, :isNew => true, :isError => true, :errorString => "Something has gone wrong."},
+                      {:id => 456, :isNew => false, :isError => false, :errorString => "This isn't an error."}
+                  ]
+              }
+          }
+      }
+
+      expected = Nokogiri.XML(%{
+        <env:Envelope
+          xmlns:lol0="http://api.bronto.com/v4"
+          xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+          <env:Header>
+          </env:Header>
+          <env:Body>
+            <lol0:addLoginsResponse>
+               <return>
+                  <errors>123</errors>
+                  <errors>456</errors>
+                  <results>
+                    <id>123</id>
+                    <isNew>true</isNew>
+                    <isError>true</isError>
+                    <errorString>Something has gone wrong.</errorString>
+                  </results>
+                  <results>
+                    <id>456</id>
+                    <isNew>false</isNew>
+                    <isError>false</isError>
+                    <errorString>This isn't an error.</errorString>
+                  </results>
+               </return>
+            </lol0:addLoginsResponse>
+          </env:Body>
+        </env:Envelope>
+      })
+
+      result = Nokogiri.XML(add_logins.build_response)
+
+      expect(result).to be_equivalent_to(expected).respecting_element_order
+    end
+  end
+end


### PR DESCRIPTION
As part of another project I'd like to mock a SOAP web service. Savon currently lets me build and validate requests but being able to create valid responses using Savon would be exteremely useful, especially as it handles namespaces correctly.

To facilitate this I've added the following methods to the Operation class:
- example_response_body 
- build_response
