### PR TITLE
Make explicit typecast for HTTP::Message

### DIFF
--- a/lib/savon/resolver.rb
+++ b/lib/savon/resolver.rb
@@ -10,7 +10,9 @@ class Savon
 
     def resolve(location)
       case location
-        when URL_PATTERN then @http.get(location)
+        when URL_PATTERN then
+          result = @http.get(location)
+          result.is_a?(HTTP::Message) ? result.body : result
         when XML_PATTERN then location
         else                  File.read(location)
       end


### PR DESCRIPTION
Resolver returned a raw HTTP::Message which resulted in implicitness
errors when used on imports.

By explicitely calling #body on HTTP::Message objects this is resolved.
