### PR TITLE
#546 making request with raw xml using xml_envelope()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 3.0.0 (branch)
+* Fix: [#546] (https://github.com/savonrb/savon/issues/546) Making request with raw xml, shortcutting the build method: `operation.xml_envelope`
+
 * Fix: [#539] (https://github.com/savonrb/savon/issues/539) Implement element form 'qualified' or 'unqualified' correctly
 
 * This version requires Ruby 1.9.2 or higher. Ruby 1.8 is no longer supported!

--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -75,9 +75,14 @@ class Savon
       Envelope.new(@operation, header, body).to_s
     end
 
+    # Public: Sets the request envelope XML. Use in place of body().
+    attr_accessor :xml_envelope
+
     # Public: Call the operation.
     def call
-      raw_response = @http.post(endpoint, http_headers, build)
+      message = (xml_envelope != nil ? xml_envelope : build)
+
+      raw_response = @http.post(endpoint, http_headers, message)
       Response.new(raw_response)
     end
 

--- a/spec/savon/operation_spec.rb
+++ b/spec/savon/operation_spec.rb
@@ -119,6 +119,35 @@ describe Savon::Operation do
     end
   end
 
+  describe '#xml_envelope' do
+    let(:xml) do
+      '<?xml version="1.0" encoding="UTF-8"?>
+    <Envelope>
+      <Body>
+        <VerifySignature>
+          <UrlEndPoint></UrlEndPoint>
+          <HttpParameters></HttpParameters>
+        </VerifySignature>
+      </Body>
+    </Envelope>'
+    end
+
+    it 'returns the xml request' do
+      http_mock.fake_request('http://www.webservicex.net/ConvertTemperature.asmx')
+      operation.xml_envelope = xml
+
+      expect(operation.xml_envelope).to eq(xml)
+    end
+
+    it 'returns a Savon response object' do
+      http_mock.fake_request('http://www.webservicex.net/ConvertTemperature.asmx')
+      operation.xml_envelope = xml
+
+      response = operation.call
+      expect(response).to be_a(Savon::Response)
+    end
+  end
+
   describe '#call' do
     it 'calls the operation with a Hash of options and returns a Response' do
       http_mock.fake_request('http://www.webservicex.net/ConvertTemperature.asmx')


### PR DESCRIPTION
set raw xml for request using `operation.xml_envelope` (`bypassing operation.build`) use xml_envelope in lieu of `operation.body`. 

future enhancement: parse out raw xml set in xml_envelope and populate operation.body and operation.header so using their respective readers still return correctly (instead of nil). 
