### PR TITLE
Fix build-breaking dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pkg
 .rspec
 .bundle
 Gemfile.lock
+bin/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ if ENV['GRAPH']
 end
 
 require 'equivalent-xml'
+require 'equivalent-xml/rspec_matchers'
 
 support_files = File.expand_path('spec/support/**/*.rb')
 Dir[support_files].each { |file| require file }


### PR DESCRIPTION
Fixes failed build https://travis-ci.org/savonrb/savon/builds/21708812

Adds bin/\* to .gitignore, so that Bundler binstubs can be used.
