### PR TITLE
Introduce convert_attributes_to global option.

### DIFF
--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -54,6 +54,7 @@ module Savon
         :raise_errors              => true,
         :strip_namespaces          => true,
         :convert_response_tags_to  => lambda { |tag| tag.snakecase.to_sym},
+        :convert_attributes_to     => lambda { |k,v| [k,v] },
         :multipart                 => false,
       }
 
@@ -251,6 +252,13 @@ module Savon
     # Defaults to convert tags to snakecase Symbols.
     def convert_response_tags_to(converter = nil, &block)
       @options[:convert_response_tags_to] = block || converter
+    end
+
+    # Tell Nori how to convert XML attributes on tags from the SOAP response into Hash keys.
+    # Accepts a lambda or a block which receives an XML tag and returns a Hash key.
+    # Defaults to doing nothing
+    def convert_attributes_to(converter = nil, &block)
+      @options[:convert_attributes_to] = block || converter
     end
 
     # Instruct Savon to create a multipart response if available.

--- a/lib/savon/response.rb
+++ b/lib/savon/response.rb
@@ -98,10 +98,11 @@ module Savon
       return @nori if @nori
 
       nori_options = {
-        :strip_namespaces     => @globals[:strip_namespaces],
-        :convert_tags_to      => @globals[:convert_response_tags_to],
-        :advanced_typecasting => @locals[:advanced_typecasting],
-        :parser               => @locals[:response_parser]
+        :strip_namespaces      => @globals[:strip_namespaces],
+        :convert_tags_to       => @globals[:convert_response_tags_to],
+        :convert_attributes_to => @globals[:convert_attributes_to],
+        :advanced_typecasting  => @locals[:advanced_typecasting],
+        :parser                => @locals[:response_parser]
       }
 
       non_nil_nori_options = nori_options.reject { |_, value| value.nil? }

--- a/spec/fixtures/response/f5.xml
+++ b/spec/fixtures/response/f5.xml
@@ -1,0 +1,39 @@
+<E:Envelope
+        xmlns:E="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:A="http://schemas.xmlsoap.org/soap/encoding/"
+        xmlns:s="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:y="http://www.w3.org/2001/XMLSchema"
+        xmlns:iControl="urn:iControl"
+        E:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<E:Body>
+<m:get_agent_listen_addressResponse
+        xmlns:m="urn:iControl:Management/SNMPConfiguration">
+<return
+        s:type="A:Array"
+        A:arrayType="iControl:Management.SNMPConfiguration.AgentListenAddressPort[2]">
+<item>
+<transport
+        s:type="iControl:Management.SNMPConfiguration.TransportType">TRANSPORT_TCP6</transport>
+<ipport
+        s:type="iControl:Common.IPPortDefinition">
+<address
+        s:type="y:string"></address>
+<port
+        s:type="y:long">161</port>
+</ipport>
+</item>
+<item>
+<transport
+        s:type="iControl:Management.SNMPConfiguration.TransportType">TRANSPORT_UDP6</transport>
+<ipport
+        s:type="iControl:Common.IPPortDefinition">
+<address
+        s:type="y:string"></address>
+<port
+        s:type="y:long">161</port>
+</ipport>
+</item>
+</return>
+</m:get_agent_listen_addressResponse>
+</E:Body>
+</E:Envelope>

--- a/spec/savon/response_spec.rb
+++ b/spec/savon/response_spec.rb
@@ -118,6 +118,16 @@ describe Savon::Response do
       expect(header.keys).to include('SESSIONNUMBER')
     end
 
+    it 'respects the global :convert_attributes_to option' do
+      globals[:convert_attributes_to] = lambda { |k,v| [] }
+
+      response_with_header = soap_response(:body => Fixture.response(:header))
+      header = response_with_header.header
+
+      expect(header).to be_a(Hash)
+      expect(header.keys).to include(:session_number)
+    end
+
     it "should throw an exception when the response header isn't parsable" do
       lambda { invalid_soap_response.header }.should raise_error Savon::InvalidResponseError
     end


### PR DESCRIPTION
This adds in the ability to convert attributes on tags in some way, by
passing either a lambda or block.  It requires the current master
branch of Nori, not 2.3.0.
