### PR TITLE
Add local option for wsse_auth and wsse_timestamp

### DIFF
--- a/lib/savon/header.rb
+++ b/lib/savon/header.rb
@@ -8,8 +8,8 @@ module Savon
     def initialize(globals, locals)
       @gyoku_options  = { :key_converter => globals[:convert_request_keys_to] }
 
-      @wsse_auth      = globals[:wsse_auth]
-      @wsse_timestamp = globals[:wsse_timestamp]
+      @wsse_auth      = locals[:wsse_auth] || globals[:wsse_auth]
+      @wsse_timestamp = locals[:wsse_timestamp] || globals[:wsse_timestamp]
 
       @global_header  = globals[:soap_header]
       @local_header   = locals[:soap_header]

--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -346,5 +346,15 @@ module Savon
       @options[:multipart] = multipart
     end
 
+    # WSSE auth credentials for Akami.
+    def wsse_auth(*credentials)
+      @options[:wsse_auth] = credentials.flatten
+    end
+
+    # Instruct Akami to enable wsu:Timestamp headers.
+    def wsse_timestamp(*timestamp)
+      @options[:wsse_timestamp] = timestamp.flatten
+    end
+
   end
 end


### PR DESCRIPTION
Fixes https://github.com/savonrb/savon/issues/575

I've also added `wsse_timestamp` in addition to `wsse_auth` as I think they logically fit together.

Because of the use of a splat for the `wsse_timestamp` argument, regardless of its setting of `true` or `false`, it will always generate a timestamp (since `@wsse_timestamp` is set to an Array). Should we be able to override a global `wsse_timestamp: true` with a local `locals.wsse_timestamp(false)` to not output the timestamp header?
