### PR TITLE
Setting ssl version fails, update httpi gem to v2.2

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency "nori",     "~> 2.4.0"
-  s.add_dependency "httpi",    "~> 2.1.0"
+  s.add_dependency "httpi",    "~> 2.2.0"
   s.add_dependency "wasabi",   "~> 3.3.0"
   s.add_dependency "akami",    "~> 1.2.0"
   s.add_dependency "gyoku",    "~> 1.1.0"


### PR DESCRIPTION
Setting ssl version fails because of a [bug](https://github.com/savonrb/httpi/pull/109) in [httpi](https://github.com/savonrb/httpi) gem. As it's fixed now, httpi gem version update is required.

``` ruby
require 'savon'
Savon.client(wsdl: 'https://example.endpoint.with.tls/wsdl', ssl_version: :TLSv1).operations
```

``` ruby
HTTPI::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read server hello A: sslv3 alert handshake failure
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/httpi-2.1.0/lib/httpi/adapter/httpclient.rb:28:in `rescue in request'
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/httpi-2.1.0/lib/httpi/adapter/httpclient.rb:25:in `request'
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/httpi-2.1.0/lib/httpi.rb:140:in `request'
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/httpi-2.1.0/lib/httpi.rb:106:in `get'
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/wasabi-3.3.0/lib/wasabi/resolver.rb:43:in `load_from_remote'
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/wasabi-3.3.0/lib/wasabi/resolver.rb:33:in `resolve'
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/wasabi-3.3.0/lib/wasabi/document.rb:142:in `xml'
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/wasabi-3.3.0/lib/wasabi/document.rb:160:in `parse'
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/wasabi-3.3.0/lib/wasabi/document.rb:147:in `parser'
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/wasabi-3.3.0/lib/wasabi/document.rb:64:in `soap_actions'
    from /home/kaa/.rvm/gems/ruby-2.0.0-p195@roombeats/gems/savon-2.5.1/lib/savon/client.rb:28:in `operations'
    from (irb):2
    from /home/kaa/.rvm/rubies/ruby-2.0.0-p195/bin/irb:12:in `<main>'
```
