### PR TITLE
Nori raises error when trying to return SoapFault error message

### DIFF
--- a/lib/savon/response.rb
+++ b/lib/savon/response.rb
@@ -22,7 +22,7 @@ module Savon
     alias_method :successful?, :success?
 
     def soap_fault?
-      SOAPFault.present? @http
+      SOAPFault.present?(@http, xml)
     end
 
     def http_error?
@@ -77,7 +77,7 @@ module Savon
     private
 
     def build_soap_and_http_errors!
-      @soap_fault = SOAPFault.new(@http, nori) if soap_fault?
+      @soap_fault = SOAPFault.new(@http, nori, xml) if soap_fault?
       @http_error = HTTPError.new(@http) if http_error?
     end
 

--- a/lib/savon/soap_fault.rb
+++ b/lib/savon/soap_fault.rb
@@ -3,20 +3,22 @@ require "savon"
 module Savon
   class SOAPFault < Error
 
-    def self.present?(http)
-      fault_node  = http.body.include?("Fault>")
-      soap1_fault = http.body.include?("faultcode>") && http.body.include?("faultstring>")
-      soap2_fault = http.body.include?("Code>") && http.body.include?("Reason>")
+    def self.present?(http, xml = nil)
+      xml ||= http.body
+      fault_node  = xml.include?("Fault>")
+      soap1_fault = xml.include?("faultcode>") && xml.include?("faultstring>")
+      soap2_fault = xml.include?("Code>") && xml.include?("Reason>")
 
       fault_node && (soap1_fault || soap2_fault)
     end
 
-    def initialize(http, nori)
+    def initialize(http, nori, xml = nil)
+      @xml = xml
       @http = http
       @nori = nori
     end
 
-    attr_reader :http, :nori
+    attr_reader :http, :nori, :xml
 
     def to_s
       fault = nori.find(to_hash, 'Fault')
@@ -24,7 +26,7 @@ module Savon
     end
 
     def to_hash
-      parsed = nori.parse(@http.body)
+      parsed = nori.parse(xml || http.body)
       nori.find(parsed, 'Envelope', 'Body')
     end
 


### PR DESCRIPTION
The problem happens when `SoapFault#to_hash` fails to parse the soap message and returns `nil` instead of a hash. The `to_s` method expects `to_hash` to return a hash and fails when it returns `nil`

Here's the relevant code:

``` ruby
# lib/savon/soap_fault.rb

def to_s
  fault = nori.find(to_hash, 'Fault') # raises error in Nori since to_hash returns nil
  message_by_version(fault)
end

def to_hash
  parsed = nori.parse(@http.body)
  nori.find(parsed, 'Envelope', 'Body') # returns nil
end
```

and the relevant backtrace:

```
/nori-2.4.0/lib/nori.rb:71:in `find_value': undefined method `each' for nil:NilClass (NoMethodError)
    from /home/dave/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/nori-2.4.0/lib/nori.rb:37:in `find'
    from /home/dave/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/savon-2.6.0/lib/savon/soap_fault.rb:22:in `to_s'
```

This should be fairly trivial to fix so I'll write a test case and submit a pull request soon.
