### PR TITLE
Allow setting ssl certs and keys as strings

### DIFF
--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -225,6 +225,11 @@ module Savon
       @options[:ssl_cert_key_file] = file
     end
 
+    # Sets the cert key to use.
+    def ssl_cert_key(key)
+      @options[:ssl_cert_key] = key
+    end
+
     # Sets the cert key password to use.
     def ssl_cert_key_password(password)
       @options[:ssl_cert_key_password] = password
@@ -235,10 +240,21 @@ module Savon
       @options[:ssl_cert_file] = file
     end
 
+    # Sets the cert to use.
+    def ssl_cert(cert)
+      @options[:ssl_cert] = cert
+    end
+
     # Sets the ca cert file to use.
     def ssl_ca_cert_file(file)
       @options[:ssl_ca_cert_file] = file
     end
+
+    # Sets the ca cert to use.
+    def ssl_ca_cert(cert)
+      @options[:ssl_ca_cert] = cert
+    end
+
 
     # HTTP basic auth credentials.
     def basic_auth(*credentials)

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -28,8 +28,11 @@ module Savon
       @http_request.auth.ssl.verify_mode   = @globals[:ssl_verify_mode]   if @globals.include? :ssl_verify_mode
 
       @http_request.auth.ssl.cert_key_file = @globals[:ssl_cert_key_file] if @globals.include? :ssl_cert_key_file
+      @http_request.auth.ssl.cert_key      = @globals[:ssl_cert_key] if @globals.include? :ssl_cert_key
       @http_request.auth.ssl.cert_file     = @globals[:ssl_cert_file]     if @globals.include? :ssl_cert_file
+      @http_request.auth.ssl.cert          = @globals[:ssl_cert]     if @globals.include? :ssl_cert
       @http_request.auth.ssl.ca_cert_file  = @globals[:ssl_ca_cert_file]  if @globals.include? :ssl_ca_cert_file
+      @http_request.auth.ssl.ca_cert       = @globals[:ssl_ca_cert]  if @globals.include? :ssl_ca_cert
 
       @http_request.auth.ssl.cert_key_password = @globals[:ssl_cert_key_password] if @globals.include? :ssl_cert_key_password
     end

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -397,6 +397,17 @@ describe "Options" do
     end
   end
 
+  context "global :ssl_cert_key" do
+    it "sets the cert key to use" do
+      cert_key = File.open(File.expand_path("../../fixtures/ssl/client_key.pem", __FILE__)).read
+      HTTPI::Auth::SSL.any_instance.expects(:cert_key=).with(cert_key).twice
+
+      client = new_client(:endpoint => @server.url, :ssl_cert_key => cert_key)
+      client.call(:authenticate)
+    end
+  end
+
+
   context "global :ssl_cert_key_password" do
     it "sets the encrypted cert key file password to use" do
       cert_key = File.expand_path("../../fixtures/ssl/client_encrypted_key.pem", __FILE__)
@@ -420,6 +431,16 @@ describe "Options" do
     end
   end
 
+  context "global :ssl_cert" do
+    it "sets the cert to use" do
+      cert = File.open(File.expand_path("../../fixtures/ssl/client_cert.pem", __FILE__)).read
+      HTTPI::Auth::SSL.any_instance.expects(:cert=).with(cert).twice
+
+      client = new_client(:endpoint => @server.url, :ssl_cert => cert)
+      client.call(:authenticate)
+    end
+  end
+
   context "global :ssl_ca_cert_file" do
     it "sets the ca cert file to use" do
       ca_cert = File.expand_path("../../fixtures/ssl/client_cert.pem", __FILE__)
@@ -429,6 +450,17 @@ describe "Options" do
       client.call(:authenticate)
     end
   end
+
+  context "global :ssl_ca_cert" do
+    it "sets the ca cert file to use" do
+      ca_cert = File.open(File.expand_path("../../fixtures/ssl/client_cert.pem", __FILE__)).read
+      HTTPI::Auth::SSL.any_instance.expects(:ca_cert=).with(ca_cert).twice
+
+      client = new_client(:endpoint => @server.url, :ssl_ca_cert => ca_cert)
+      client.call(:authenticate)
+    end
+  end
+
 
   context "global :basic_auth" do
     it "sets the basic auth credentials" do


### PR DESCRIPTION
At the moment Savon has ssl authentications parameters ssl_cert_file, ssl_cert_key_file, ssl_ca_cert_file. Thus, it is required to store these data in files. On the other hand, it may be sometimes convenient to store certificates, say, in a database column.

Since HTTPI provides API to set ssl certificates as strings, it seems to be possible to implement similar params in Savon, like following:

``` ruby
# Class user has fields cert and cert_key that store corresponding strings 
user = User.find(params[:id)

Savon.client(
  ssl_cert: user.cert,
  ssl_cert_key: user.cert_key,
  ssl_ca_cert_file: "lib/ca_cert.pem"
)
```
