### PR TITLE
Feature: complex log filtering.

### DIFF
--- a/lib/savon/log_message.rb
+++ b/lib/savon/log_message.rb
@@ -35,8 +35,12 @@ module Savon
     end
 
     def apply_filter!(document, filter)
-      document.xpath("//*[local-name()='#{filter}']").each do |node|
-        node.content = "***FILTERED***"
+      if filter.instance_of? Proc
+        filter.call document
+      else
+        document.xpath("//*[local-name()='#{filter}']").each do |node|
+          node.content = "***FILTERED***"
+        end
       end
     end
 

--- a/spec/savon/log_message_spec.rb
+++ b/spec/savon/log_message_spec.rb
@@ -26,6 +26,17 @@ describe Savon::LogMessage do
     expect(message).to include("<password>***FILTERED***</password>")
   end
 
+  it "properly applies Proc filter" do
+    filter = Proc.new do |document|
+      document.xpath('//password').each do |node|
+        node.content = "FILTERED"
+      end
+    end
+
+    message = log_message("<root><password>secret</password></root>", [filter], false).to_s
+    expect(message).to include("<password>FILTERED</password>")
+  end
+
   def log_message(*args)
     Savon::LogMessage.new(*args)
   end


### PR DESCRIPTION
Sometimes we need to filter log data using more complicated criteria than just a tag name. For example, `number` tag in the `document` tag normally is not filtered, but under certain circumstances can contain credit card number, which should be masked.

Code in this pull request allows developer to add Proc objects to the filters array in addition to simple tag names; each Proc object is called with document as a single parameter and can do arbitrary complex filtering / document transformations.
