### PR TITLE
Use a more recent version of gyoku

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "httpi",    "~> 2.2.3"
   s.add_dependency "wasabi",   "~> 3.3.0"
   s.add_dependency "akami",    "~> 1.2.0"
-  s.add_dependency "gyoku",    "~> 1.1.0"
+  s.add_dependency "gyoku",    "~> 1.2.2"
   s.add_dependency "uuid",     "~> 2.3.7"
 
   s.add_dependency "builder",  ">= 2.1.2"


### PR DESCRIPTION
Since savonrb/gyoku#46 is very critical for us, and we depend on Savon, it would be nice to be able to get a Savon version that depends on a newer version of `gyoku`. Because the gem version is pinned in the gemspec, it's currently impossible to use the "fixed" version of Gyoku w/ Savon - hence, this PR.

Thanks in advance.
