### PR TITLE
Fix problem with SoapFault if tag name is ServiceFault

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem "simplecov", :require => false
 gem "coveralls", :require => false
 gem "uuid"
 
+gem 'json'
+
 platform :rbx do
   gem 'json'
   gem 'racc'

--- a/lib/savon/soap_fault.rb
+++ b/lib/savon/soap_fault.rb
@@ -21,7 +21,7 @@ module Savon
     attr_reader :http, :nori, :xml
 
     def to_s
-      fault = nori.find(to_hash, 'Fault')
+      fault = nori.find(to_hash, 'Fault') || nori.find(to_hash, 'ServiceFault')
       message_by_version(fault)
     end
 
@@ -33,6 +33,7 @@ module Savon
     private
 
     def message_by_version(fault)
+      puts fault
       if nori.find(fault, 'faultcode')
         code = nori.find(fault, 'faultcode')
         text = nori.find(fault, 'faultstring')

--- a/spec/savon/soap_fault_spec.rb
+++ b/spec/savon/soap_fault_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe Savon::SOAPFault do
   let(:soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault)), nori }
   let(:soap_fault2) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault12)), nori }
+  let(:soap_fault_funky) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault_funky)), nori }
   let(:soap_fault_nc) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault)), nori_no_convert }
   let(:soap_fault_nc2) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault12)), nori_no_convert }
   let(:another_soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:another_soap_fault)), nori }
@@ -62,6 +63,10 @@ describe Savon::SOAPFault do
 
       it "works even if the keys are different in a SOAP 1.2 fault message" do
         expect(soap_fault_nc2.send method).to eq("(soap:Sender) Sender Timeout")
+      end
+
+      it "works even if the keys are different in a funky SOAP fault message" do
+        expect(soap_fault_funky.send method).to eq("(42) The Answer to Life The Universe And Everything")
       end
     end
   end


### PR DESCRIPTION
There is a discrepancy between the check of it a fault is present `fault_node  = xml.include?("Fault>")` and finding the actual fault node `fault = nori.find(to_hash, 'Fault')`

This has been fixed in one specific case but problably needs a more long term solution.

Note that I had to include json gem for my ruby 2.0 in the Gemfile to make the tests run.