### PR TITLE
Change RequestLogger to lazy message evaluation

### DIFF
--- a/lib/savon/request_logger.rb
+++ b/lib/savon/request_logger.rb
@@ -26,14 +26,14 @@ module Savon
     private
 
     def log_request(request)
-      logger.info  "SOAP request: #{request.url}"
-      logger.info  headers_to_log(request.headers)
-      logger.debug body_to_log(request.body)
+      logger.info  { "SOAP request: #{request.url}" }
+      logger.info  { headers_to_log(request.headers) }
+      logger.debug { body_to_log(request.body) }
     end
 
     def log_response(response)
-      logger.info  "SOAP response (status #{response.code})"
-      logger.debug body_to_log(response.body)
+      logger.info  { "SOAP response (status #{response.code})" }
+      logger.debug { body_to_log(response.body) }
     end
 
     def headers_to_log(headers)

--- a/spec/savon/request_logger_spec.rb
+++ b/spec/savon/request_logger_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe Savon::RequestLogger do
+
+  subject            { described_class.new(globals) }
+  let(:globals)      { Savon::GlobalOptions.new(:log => true, :pretty_print_xml => true) }
+  let(:request) {
+    stub('Request',
+         :url     => 'http://example.com',
+         :headers => [],
+         :body    => '<TestRequest />'
+        )
+  }
+
+  let(:response) {
+    stub('Response',
+         :code => 200,
+         :body => '<TestResponse />'
+        )
+  }
+
+  before(:each) {
+    globals[:logger].level = Logger::DEBUG
+  }
+
+  describe '#log_request / #log_response' do
+    it 'does not prepare log messages when no logging is needed' do
+      begin
+        globals[:logger].level = Logger::FATAL
+
+        Savon::LogMessage.expects(:new).never
+        subject.log(request) { response }
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
This PR uses the Logger block form that the expensive xml pretty printing is only done when needed.

Some other specs were checking for log messages via message expectations. I had to change them to output capturing