### PR TITLE
Add xmlns:wsa to wsa:MessageID.

### DIFF
--- a/lib/savon/header.rb
+++ b/lib/savon/header.rb
@@ -61,7 +61,12 @@ module Savon
        convert_to_xml({
          'wsa:Action' => @locals[:soap_action],
          'wsa:To' => @globals[:endpoint],
-         'wsa:MessageID' => "urn:uuid:#{UUID.new.generate}"
+         'wsa:MessageID' => "urn:uuid:#{UUID.new.generate}",
+         attributes!: {
+          'wsa:MessageID' => {
+            "xmlns:wsa" => "http://schemas.xmlsoap.org/ws/2004/08/addressing"
+          }
+         }
        })
     end
 


### PR DESCRIPTION
I was getting 500s from an external API we're trying to integrate with and one of the causes was that the `xmlns:wsa` attribute wasn't set on the `wsa:MessageID` header using the `use_wsa_headers` option. This is monkey-patched in our internal codebase, but would be great to get this merged into master!

Thanks!