### PR TITLE
Bump wasabi to remove mime-types dependency

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "nori",     "~> 2.4"
   s.add_dependency "httpi",    "~> 2.3"
-  s.add_dependency "wasabi",   "3.3.0"
+  s.add_dependency "wasabi",   "3.3.1"
   s.add_dependency "akami",    "~> 1.2"
   s.add_dependency "gyoku",    "~> 1.2"
   s.add_dependency "uuid",     "~> 2.3.7"


### PR DESCRIPTION
We needed this to avoid a version conflict with Poltergeist:

```
Bundler could not find compatible versions for gem "mime-types":
  In Gemfile:
    savon (~> 2.8.0) ruby depends on
      wasabi (= 3.3.0) ruby depends on
        mime-types (< 2.0.0) ruby

    poltergeist (>= 1.5.0) ruby depends on
      capybara (~> 2.1) ruby depends on
        mime-types (2.4.3)
```
