### PR TITLE
Add support for matchers in the message expectation.

### DIFF
--- a/lib/savon/mock/expectation.rb
+++ b/lib/savon/mock/expectation.rb
@@ -54,8 +54,8 @@ module Savon
     end
 
     def verify_message!
-      return if @expected[:message] == :any
-      unless @expected[:message] == @actual[:message]
+      return if @expected[:message].eql? :any
+      unless @expected[:message] === @actual[:message]
         expected_message = "  with this message: #{@expected[:message].inspect}" if @expected[:message]
         expected_message ||= "  with no message."
 

--- a/spec/savon/mock_spec.rb
+++ b/spec/savon/mock_spec.rb
@@ -127,6 +127,12 @@ describe "Savon's mock interface" do
     expect { new_client.call(:find_user) }.to_not raise_error
   end
 
+  it "matchers can be used to specify the message" do
+    savon.expects(:find_user).with(:message => include(:username)).returns("<fixture/>")
+    message = { :username => "Han Solo", password: "querty"}
+
+    expect { new_client.call(:find_user, :message => message) }.to_not raise_error
+  end
 
   it "allows code to rescue Savon::Error and still report test failures" do
     message = { :username => "luke" }


### PR DESCRIPTION
This makes the expectactions more flexible, as it is not needed to know the full message.

The specs are using rspec 2.x, but in 3.x it also enables things like:

```ruby
savon.expects(:find_user).with(:message => include(:username => match(/Han/))).returns("<fixture/>")
message = { :username => "Han Solo", password: "querty"}

expect { new_client.call(:find_user, :message => message) }.to_not raise_error
```

Any thougts?