### PR TITLE
closes #672 add unwrap option and pass it to Gyoku

### DIFF
--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -166,7 +166,7 @@ module Savon
       element_form_default = @globals[:element_form_default] || @wsdl.element_form_default
       # TODO: clean this up! [dh, 2012-12-17]
       Message.new(message_tag, namespace_identifier, @types, @used_namespaces, @locals[:message],
-                  element_form_default, @globals[:convert_request_keys_to])
+                  element_form_default, @globals[:convert_request_keys_to], @globals[:unwrap])
     end
 
     def namespace_identifier

--- a/lib/savon/message.rb
+++ b/lib/savon/message.rb
@@ -4,7 +4,7 @@ require "gyoku"
 module Savon
   class Message
 
-    def initialize(message_tag, namespace_identifier, types, used_namespaces, message, element_form_default, key_converter)
+    def initialize(message_tag, namespace_identifier, types, used_namespaces, message, element_form_default, key_converter, unwrap)
       @message_tag = message_tag
       @namespace_identifier = namespace_identifier
       @types = types
@@ -13,6 +13,7 @@ module Savon
       @message = message
       @element_form_default = element_form_default
       @key_converter = key_converter
+      @unwrap = unwrap
     end
 
     def to_s
@@ -25,7 +26,8 @@ module Savon
       gyoku_options = {
         :element_form_default => @element_form_default,
         :namespace            => @namespace_identifier,
-        :key_converter        => @key_converter
+        :key_converter        => @key_converter,
+        :unwrap               => @unwrap
       }
 
       Gyoku.xml(@message, gyoku_options)

--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -89,6 +89,7 @@ module Savon
         :use_wsa_headers           => false,
         :no_message_tag            => false,
         :follow_redirects          => false,
+        :unwrap                    => false
       }
 
       options = defaults.merge(options)
@@ -285,6 +286,12 @@ module Savon
     # Accepts one of :lower_camelcase, :camelcase, :upcase, or :none.
     def convert_request_keys_to(converter)
       @options[:convert_request_keys_to] = converter
+    end
+
+    # Tell Gyoku to unwrap Array of Hashes
+    # Accepts a boolean, default to false
+    def unwrap(unwrap)
+      @options[:unwrap] = unwrap
     end
 
     # Tell Nori how to convert XML tags from the SOAP response into Hash keys.


### PR DESCRIPTION
So, this is a PR to fix this issue : https://github.com/savonrb/savon/issues/672

It depends on the merge of this PR on Gyoku : https://github.com/savonrb/gyoku/pull/52, based on @stgwilli's work.

It adds an option :unwrap to Savon::Client to be passed to Gyoku, to be able to have this
```
a = { items: [ { item: { name: 'foo' } }, { item: { name: 'bar' } ] }
```
render this
```
<items><item><name>foo</name></item><item><name>bar</name></item></items>
```
instead of this
```
<items><item><name>foo</name></item></items><items><item><name>bar</name></item></items>
```
without breaking the actual behaviour.