### PR TITLE
Allow overriding host in WSDL actions

### DIFF
--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -126,7 +126,13 @@ module Savon
     end
 
     def endpoint
-      @globals[:endpoint] || @wsdl.endpoint
+      @globals[:endpoint] || @wsdl.endpoint.tap do |url|
+        if @globals[:host]
+          host_url = URI.parse(@globals[:host])
+          url.host = host_url.host
+          url.port = host_url.port
+        end
+      end
     end
 
     def raise_expected_httpi_response!

--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -89,7 +89,8 @@ module Savon
         :use_wsa_headers           => false,
         :no_message_tag            => false,
         :follow_redirects          => false,
-        :unwrap                    => false
+        :unwrap                    => false,
+        :host                      => nil
       }
 
       options = defaults.merge(options)
@@ -106,6 +107,11 @@ module Savon
     # Location of the local or remote WSDL document.
     def wsdl(wsdl_address)
       @options[:wsdl] = wsdl_address
+    end
+
+    # set different host for actions in WSDL
+    def host(host)
+      @options[:host] = host
     end
 
     # SOAP endpoint.

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -114,6 +114,15 @@ describe "Options" do
     end
   end
 
+  context "global :host" do
+    it "overrides the WSDL endpoint host" do
+      client = new_client(:wsdl => Fixture.wsdl(:no_message_tag), host: "https://example.com:8080")
+
+      request = client.build_request(:update_orders)
+      expect(request.url.to_s).to eq "https://example.com:8080/webserviceexternal/contracts.asmx"
+    end
+  end
+
   context "global :headers" do
     it "sets the HTTP headers for the next request" do
       client = new_client(:endpoint => @server.url(:inspect_request), :headers => { "X-Token" => "secret" })


### PR DESCRIPTION
This patch adds the `host` global option, which allows you to override the host in the endpoints of the WSDL.

Example use case:

```ruby
@client = Savon.client(wsdl: "https://www.example.com/wsdl", host: "https://255:255:255:255:8080")

@client.call(:example_call) 
# WSDL defines as "https://www.example.com/sap/example_call_binding"
# Now client calls "https://255.255.255.255:8080/sap/example_call_binding"
```

My particular use case is accessing a third-party service through a VPN. The service is made accessible through a white-listed IP address, but the service defines its endpoints using an internal DNS. While we can access the WSDL, we can't use it in its current state because the endpoints don't resolve outside of the third party's network.