### PR TITLE
Add Rubinius back to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ rvm:
 matrix:
   allow_failures:
     - rvm: rbx-2
+  fast_finish: true
 notifications:
   irc: "irc.freenode.org#savon"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,9 @@ rvm:
   - 2.1
   - 2.2
   - jruby
+  - rbx-2
+matrix:
+  allow_failures:
+    - rvm: rbx-2
 notifications:
   irc: "irc.freenode.org#savon"


### PR DESCRIPTION
I noticed that 71b9a1f removed CI support for Rubinius, but doc site states Rubinius (at least 1.8 and 1.9) are supported.