### PR TITLE
Replace UUID with SecureRandom.uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.11.1 (2015-05-27)
+
+* Replace dependency on [uuid](https://rubygems.org/gems/uuid), using SecureRandom.uuid instead.
+
 # 2.11.0 (2015-03-31)
 
 * Formally drop support for 1.8.7. 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "httpclient", "~> 2.3.4"
 
 gem "simplecov", :require => false
 gem "coveralls", :require => false
-gem "uuid"
 
 platform :rbx do
   gem 'json'

--- a/lib/savon/header.rb
+++ b/lib/savon/header.rb
@@ -1,6 +1,6 @@
 require "akami"
 require "gyoku"
-require "uuid"
+require "securerandom"
 
 module Savon
   class Header
@@ -61,7 +61,7 @@ module Savon
        convert_to_xml({
          'wsa:Action' => @locals[:soap_action],
          'wsa:To' => @globals[:endpoint],
-         'wsa:MessageID' => "urn:uuid:#{UUID.new.generate}",
+         'wsa:MessageID' => "urn:uuid:#{SecureRandom.uuid}",
          attributes!: {
           'wsa:MessageID' => {
             "xmlns:wsa" => "http://schemas.xmlsoap.org/ws/2004/08/addressing"

--- a/lib/savon/version.rb
+++ b/lib/savon/version.rb
@@ -1,3 +1,3 @@
 module Savon
-  VERSION = '2.11.0'
+  VERSION = '2.11.1'
 end

--- a/savon.gemspec
+++ b/savon.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency "wasabi",   "~> 3.4"
   s.add_dependency "akami",    "~> 1.2"
   s.add_dependency "gyoku",    "~> 1.2"
-  s.add_dependency "uuid",     "~> 2.3.7"
   s.add_dependency "builder",  ">= 2.1.2"
   s.add_dependency "nokogiri", ">= 1.4.0"
 


### PR DESCRIPTION
Savon uses the [uuid](https://rubygems.org/gems/uuid/versions/2.3.7) gem which does some pretty heavy lifting to generate UUIDs (e.g., shelling out via [systemu](https://rubygems.org/gems/systemu/versions/2.6.5)). This PR removes this dependency, using Ruby's own [SecureRandom.uuid](http://ruby-doc.org/stdlib-1.9.3/libdoc/securerandom/rdoc/SecureRandom.html#method-c-uuid).