### PR TITLE
solves the problem reported in the issue #728

### DIFF
--- a/lib/savon/qualified_message.rb
+++ b/lib/savon/qualified_message.rb
@@ -23,7 +23,7 @@ module Savon
           translated_key << "!" if key[-1] == "!"
           newpath = path + [translated_key]
 
-          if @used_namespaces[newpath]
+          if @used_namespaces[newpath] and @key_converter != :none
             newhash.merge(
               "#{@used_namespaces[newpath]}:#{translated_key}" =>
                 to_hash(value, @types[newpath] ? [@types[newpath]] : newpath)


### PR DESCRIPTION
when you set convert_request_keys_to: as :none
doesn't add prefix 'xmlns:' to the body's attributes in the XML
