### PR TITLE
Update spec SSL options

### DIFF
--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -389,9 +389,9 @@ describe "Options" do
 
   context "global :ssl_version" do
     it "sets the SSL version to use" do
-      HTTPI::Auth::SSL.any_instance.expects(:ssl_version=).with(:SSLv3).twice
+      HTTPI::Auth::SSL.any_instance.expects(:ssl_version=).with(:TLSv1).twice
 
-      client = new_client(:endpoint => @server.url, :ssl_version => :SSLv3)
+      client = new_client(:endpoint => @server.url, :ssl_version => :TLSv1)
       client.call(:authenticate)
     end
   end

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -398,9 +398,9 @@ describe "Options" do
 
   context "global :ssl_verify_mode" do
     it "sets the verify mode to use" do
-      HTTPI::Auth::SSL.any_instance.expects(:verify_mode=).with(:none).twice
+      HTTPI::Auth::SSL.any_instance.expects(:verify_mode=).with(:peer).twice
 
-      client = new_client(:endpoint => @server.url, :ssl_verify_mode => :none)
+      client = new_client(:endpoint => @server.url, :ssl_verify_mode => :peer)
       client.call(:authenticate)
     end
   end

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -60,8 +60,8 @@ describe Savon::WSDLRequest do
 
     describe "ssl version" do
       it "is set when specified" do
-        globals.ssl_version(:SSLv3)
-        http_request.auth.ssl.expects(:ssl_version=).with(:SSLv3)
+        globals.ssl_version(:TLSv1)
+        http_request.auth.ssl.expects(:ssl_version=).with(:TLSv1)
 
         new_wsdl_request.build
       end
@@ -364,8 +364,8 @@ describe Savon::SOAPRequest do
 
     describe "ssl version" do
       it "is set when specified" do
-        globals.ssl_version(:SSLv3)
-        http_request.auth.ssl.expects(:ssl_version=).with(:SSLv3)
+        globals.ssl_version(:TLSv1)
+        http_request.auth.ssl.expects(:ssl_version=).with(:TLSv1)
 
         new_soap_request.build
       end

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -74,8 +74,8 @@ describe Savon::WSDLRequest do
 
     describe "ssl verify mode" do
       it "is set when specified" do
-        globals.ssl_verify_mode(:none)
-        http_request.auth.ssl.expects(:verify_mode=).with(:none)
+        globals.ssl_verify_mode(:peer)
+        http_request.auth.ssl.expects(:verify_mode=).with(:peer)
 
         new_wsdl_request.build
       end
@@ -378,8 +378,8 @@ describe Savon::SOAPRequest do
 
     describe "ssl verify mode" do
       it "is set when specified" do
-        globals.ssl_verify_mode(:none)
-        http_request.auth.ssl.expects(:verify_mode=).with(:none)
+        globals.ssl_verify_mode(:peer)
+        http_request.auth.ssl.expects(:verify_mode=).with(:peer)
 
         new_soap_request.build
       end


### PR DESCRIPTION
This PR updates the SSL options in the specs, so that:
1. They use TLS 1.0 instead of the obsolete, deprecated, and vulnerable SSL 3.0
2. They verify SSL certificates instead of trusting them.

The users of this gem may seek to learn best practices from the specs. If they do, it would be better if the specs demonstrate how to securely use SSL options. That way, users don't become vulnerable to [POODLE](https://en.wikipedia.org/wiki/POODLE) or man-in-the-middle attacks.
