### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # https://github.com/travis-ci/travis-ci/wiki/.travis.yml-options
 language: "ruby"
+sudo: false
 before_install:
   - gem install bundler
 script: "bundle exec rake --trace"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ before_install:
   - gem install bundler
 script: "bundle exec rake --trace"
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
+  - 2.0.0
+  - 2.1.8
+  - 2.2.4
   - 2.3.0
   - jruby
   - rbx-2


### PR DESCRIPTION
Hey there,

One more tiny PR from me. Basically this one does 2 things:

1. Forces TravisCI to use their container-based infrastructure which is now default and promises faster start-up times (https://docs.travis-ci.com/user/workers/container-based-infrastructure/)

2. I've noticed that omitting minor ruby version will use older (most likely cached) version on TravisCI:

![Ruby 2.1](http://d.pr/i/1c0OC+)

![Ruby 2.2](http://d.pr/i/14aC4+)