### PR TITLE
Add support for local request headers

### DIFF
--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -100,7 +100,8 @@ module Savon
 
       request = SOAPRequest.new(@globals).build(
         :soap_action => soap_action,
-        :cookies     => @locals[:cookies]
+        :cookies     => @locals[:cookies],
+        :headers     => @locals[:headers]
       )
 
       request.url = endpoint

--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -406,5 +406,9 @@ module Savon
     def multipart(multipart)
       @options[:multipart] = multipart
     end
+
+    def headers(headers)
+      @options[:headers] = headers
+    end
   end
 end

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -74,7 +74,7 @@ module Savon
       configure_proxy
       configure_cookies options[:cookies]
       configure_timeouts
-      configure_headers options[:soap_action]
+      configure_headers options[:soap_action], options[:headers]
       configure_ssl
       configure_auth
       configure_redirect_handling
@@ -88,8 +88,9 @@ module Savon
       @http_request.set_cookies(cookies) if cookies
     end
 
-    def configure_headers(soap_action)
+    def configure_headers(soap_action, headers)
       @http_request.headers = @globals[:headers] if @globals.include? :headers
+      @http_request.headers.merge!(headers) if headers
       @http_request.headers["SOAPAction"]   ||= %{"#{soap_action}"} if soap_action
       @http_request.headers["Content-Type"] ||= CONTENT_TYPE[@globals[:soap_version]] % @globals[:encoding]
     end

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -1046,6 +1046,17 @@ describe "Options" do
     end
   end
 
+  context "request :headers" do
+    it "sets headers" do
+      client = new_client(:endpoint => @server.url(:inspect_request))
+
+      response = client.call(:authenticate, :headers => { "X-Token" => "secret" })
+      x_token  = inspect_request(response).x_token
+
+      expect(x_token).to eq("secret")
+    end
+  end
+
   def new_client(globals = {}, &block)
     globals = { :wsdl => Fixture.wsdl(:authentication), :log => false }.merge(globals)
     Savon.client(globals, &block)


### PR DESCRIPTION
Allows you to pass in headers to the `Savon::Client#call` method in the same way as global headers. These headers will be sent with the request.

```
client.call(endpoint, headers: { 'foo' => 'bar' }) do
  ...
end
```
