### PR TITLE
Adding an allow method in addition to expects to spec helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+# 2.11.2 (2016-03-09)
+
+* add allow method to spec_helper in addition to expects method
+
 # 2.11.1 (2015-05-27)
 
 * Replace dependency on [uuid](https://rubygems.org/gems/uuid), using SecureRandom.uuid instead.
 
 # 2.11.0 (2015-03-31)
 
-* Formally drop support for 1.8.7. 
+* Formally drop support for 1.8.7.
 
 # 2.10.1 (2015-03-15)
 

--- a/lib/savon/version.rb
+++ b/lib/savon/version.rb
@@ -1,3 +1,3 @@
 module Savon
-  VERSION = '2.11.1'
+  VERSION = '2.11.2'
 end


### PR DESCRIPTION
This helps developers set up multiple operation responses, that may be called in different orders.

This is specifically useful for mocking out a third party service which cannot be called in development.

This is designed to address issue https://github.com/savonrb/savon/issues/746
