### PR TITLE
Add headers configuration to WSDLRequest#build

### DIFF
--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -55,11 +55,18 @@ module Savon
     def build
       configure_proxy
       configure_timeouts
+      configure_headers
       configure_ssl
       configure_auth
       configure_redirect_handling
 
       @http_request
+    end
+
+    private
+
+    def configure_headers
+      @http_request.headers = @globals[:headers] if @globals.include? :headers
     end
   end
 

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -16,6 +16,20 @@ describe Savon::WSDLRequest do
       expect(wsdl_request.build).to be_an(HTTPI::Request)
     end
 
+    describe "headers" do
+      it "are set when specified" do
+        globals.headers("Proxy-Authorization" => "Basic auth")
+        configured_http_request = new_wsdl_request.build
+
+        expect(configured_http_request.headers["Proxy-Authorization"]).to eq("Basic auth")
+      end
+
+      it "are not set otherwise" do
+        configured_http_request = new_wsdl_request.build
+        expect(configured_http_request.headers).to_not include("Proxy-Authorization")
+      end
+    end
+
     describe "proxy" do
       it "is set when specified" do
         globals.proxy("http://proxy.example.com")


### PR DESCRIPTION
e.g. some proxy servers may require

``` ruby
{ "Proxy-Authorization" => "Basic base64EncodedAuthHash" }
```

as part of the headers.

In particular we ran into issues with using the Proximo Heroku Add-On.

This fixes #750 and may be considered a late addition to #378.
