### PR TITLE
Logging: Use filter without automatic pretty printing

### DIFF
--- a/lib/savon/log_message.rb
+++ b/lib/savon/log_message.rb
@@ -45,7 +45,7 @@ module Savon
     end
 
     def nokogiri_options
-      @pretty_print ? { :indent => 2 } : {}
+      @pretty_print ? { :indent => 2 } : { :save_with => Nokogiri::XML::Node::SaveOptions::AS_XML }
     end
 
   end

--- a/spec/savon/log_message_spec.rb
+++ b/spec/savon/log_message_spec.rb
@@ -21,9 +21,15 @@ describe Savon::LogMessage do
     expect(message).to include("\n  <body>")
   end
 
-  it "filters tags in a given message" do
+  it "filters tags in a given message without pretty printing" do
     message = log_message("<root><password>secret</password></root>", [:password], false).to_s
     expect(message).to include("<password>***FILTERED***</password>")
+    expect(message).to_not include("\n  <password>***FILTERED***</password>") # no pretty printing
+  end
+
+  it "filters tags in a given message with pretty printing" do
+    message = log_message("<root><password>secret</password></root>", [:password], true).to_s
+    expect(message).to include("\n  <password>***FILTERED***</password>")
   end
 
   it "properly applies Proc filter" do


### PR DESCRIPTION
The filter functionality is using nokogiri to filter out unwanted
elements. The default `.to_xml` of nokogiri automatically pretty prints
the document, even if the pretty_print_xml option is set to false.

This commit fixes this, by applying the filter and taking the
`pretty_print_xml = false` into account.

See http://stackoverflow.com/questions/8406251/nokogiri-to-xml-without-carriage-returns
for details of using nokogiri without carriage returns.
