### PR TITLE
Restore support for cookies when using custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# NOTICE: This is a fork of savonrb/savon
+
+It's forked because savonrb has a bug when headers and sessions are combined, and even though we have opened a pull request for a fix on the official repo, it seems that:
+
+![Nobody cares](https://cdn.meme.am/instances/500x/22118345.jpg)
+
+Because of that, we are using this fork. Hopefully not for long, as the savon/rconomic duo should be retired from our systems in favor of using E-conomic's shiny new JSON/REST API.
+
+---
+
 # Savon
 
 Heavy metal SOAP client

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -72,9 +72,9 @@ module Savon
 
     def build(options = {})
       configure_proxy
-      configure_cookies options[:cookies]
       configure_timeouts
       configure_headers options[:soap_action], options[:headers]
+      configure_cookies options[:cookies]
       configure_ssl
       configure_auth
       configure_redirect_handling


### PR DESCRIPTION
This commit configures cookies AFTER configuring headers. This is necessary because the header configuration method resets existing headers, including cookies.