### PR TITLE
remove unused parameter, fix specs

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -60,7 +60,6 @@ module Savon
       @wsdl.document    = @globals[:wsdl]        if @globals.include? :wsdl
       @wsdl.endpoint    = @globals[:endpoint]    if @globals.include? :endpoint
       @wsdl.namespace   = @globals[:namespace]   if @globals.include? :namespace
-      @wsdl.servicename = @globals[:servicename] if @globals.include? :servicename
       @wsdl.adapter     = @globals[:adapter]     if @globals.include? :adapter
 
       @wsdl.request = WSDLRequest.new(@globals).build

--- a/spec/integration/random_quote_spec.rb
+++ b/spec/integration/random_quote_spec.rb
@@ -16,7 +16,7 @@ describe 'rpc/encoded binding test' do
       $stderr.puts e.to_hash.inspect
       f_c = e.to_hash[:fault][:faultstring]
       expect(f_c).not_to  eq('No such operation \'getQuoteRequest\'')
-      expect(f_c).to eq('soapenv:Server.userException')
+      expect(f_c).to eq('lucee.runtime.exp.DatabaseException: ')
       pending e
     end
   end

--- a/spec/savon/softlayer_spec.rb
+++ b/spec/savon/softlayer_spec.rb
@@ -21,7 +21,7 @@ describe Savon::Builder do
 
       locals = Savon::LocalOptions.new(message)
       builder = Savon::Builder.new(:create_object, wsdl, globals, locals)
-      expect(builder.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://api.service.softlayer.com/soap/v3/" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><createObject><templateObject xsi:type="tns:SoftLayer_Brand"><longName>Zertico LLC Reseller</longName></templateObject></createObject></env:Body></env:Envelope>')
+      expect(builder.to_s).to eq('<?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://api.service.softlayer.com/soap/v3/" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:createObject><templateObject><longName>Zertico LLC Reseller</longName></templateObject></tns:createObject></env:Body></env:Envelope>')
     end
   end
 end


### PR DESCRIPTION
 servicename global is only used in build_wsdl_document but its value is always nil because  there is no setter method for this option in Options class.

If you try to set servicename global,  Savon::UnknownOptionError is raised
```
> Savon.client(wsdl: 'http://google.com', servicename: 'afa')

 Savon::UnknownOptionError: Unknown global option: :servicename
from /home/ayrat/.rvm/gems/ruby-2.2.5/gems/savon-2.11.1/lib/savon/options.rb:36:in `method_missing'  ```