### PR TITLE
README with SVG badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Heavy metal SOAP client
 [Documentation](http://savonrb.com) | [RDoc](http://rubydoc.info/gems/savon) |
 [Mailing list](https://groups.google.com/forum/#!forum/savonrb) | [Twitter](http://twitter.com/savonrb)
 
-[![Build Status](https://secure.travis-ci.org/savonrb/savon.png?branch=master)](http://travis-ci.org/savonrb/savon)
-[![Gem Version](https://badge.fury.io/rb/savon.png)](http://badge.fury.io/rb/savon)
-[![Code Climate](https://codeclimate.com/github/savonrb/savon.png)](https://codeclimate.com/github/savonrb/savon)
-[![Coverage Status](https://coveralls.io/repos/savonrb/savon/badge.png?branch=version2)](https://coveralls.io/r/savonrb/savon)
+[![Build Status](https://secure.travis-ci.org/savonrb/savon.svg?branch=master)](http://travis-ci.org/savonrb/savon)
+[![Gem Version](https://badge.fury.io/rb/savon.svg)](http://badge.fury.io/rb/savon)
+[![Code Climate](https://codeclimate.com/github/savonrb/savon.svg)](https://codeclimate.com/github/savonrb/savon)
+[![Coverage Status](https://coveralls.io/repos/savonrb/savon/badge.svg?branch=version2)](https://coveralls.io/r/savonrb/savon)
 
 
 ## Version 2


### PR DESCRIPTION
This PR changes the build status badges in the README to use SVG, so that they have higher contrast.

Thanks for building savon.

