### PR TITLE
Add global option ssl_ciphers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.12.0
 
-* Freature: [#794](https://github.com/savonrb/savon/pull/794), add global option ssl_ciphers.
+* Feature: [#794](https://github.com/savonrb/savon/pull/794), add global option ssl_ciphers.
 
 # 2.11.1 (2015-05-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.12.0
+
+* Freature: [#794](https://github.com/savonrb/savon/pull/794), add global option ssl_ciphers.
+
 # 2.11.1 (2015-05-27)
 
 * Replace dependency on [uuid](https://rubygems.org/gems/uuid), using SecureRandom.uuid instead.

--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -268,6 +268,10 @@ module Savon
       @options[:ssl_ca_cert] = cert
     end
 
+    def ssl_ciphers(ciphers)
+      @options[:ssl_ciphers] = ciphers
+    end
+
 
     # HTTP basic auth credentials.
     def basic_auth(*credentials)

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -26,6 +26,7 @@ module Savon
     def configure_ssl
       @http_request.auth.ssl.ssl_version   = @globals[:ssl_version]       if @globals.include? :ssl_version
       @http_request.auth.ssl.verify_mode   = @globals[:ssl_verify_mode]   if @globals.include? :ssl_verify_mode
+      @http_request.auth.ssl.ciphers       = @globals[:ssl_ciphers]       if @globals.include? :ssl_ciphers
 
       @http_request.auth.ssl.cert_key_file = @globals[:ssl_cert_key_file] if @globals.include? :ssl_cert_key_file
       @http_request.auth.ssl.cert_key      = @globals[:ssl_cert_key] if @globals.include? :ssl_cert_key

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -405,6 +405,15 @@ describe "Options" do
     end
   end
 
+  context "global :ssl_ciphers" do
+    it "sets the ciphers to use" do
+      HTTPI::Auth::SSL.any_instance.expects(:ciphers=).with(:none).twice
+
+      client = new_client(:endpoint => @server.url, :ssl_ciphers => :none)
+      client.call(:authenticate)
+    end
+  end
+
   context "global :ssl_cert_key_file" do
     it "sets the cert key file to use" do
       cert_key = File.expand_path("../../fixtures/ssl/client_key.pem", __FILE__)

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -5,6 +5,7 @@ describe Savon::WSDLRequest do
 
   let(:globals)      { Savon::GlobalOptions.new }
   let(:http_request) { HTTPI::Request.new }
+  let(:ciphers)      { OpenSSL::Cipher.ciphers }
 
   def new_wsdl_request
     Savon::WSDLRequest.new(globals, http_request)
@@ -82,6 +83,20 @@ describe Savon::WSDLRequest do
 
       it "is not set otherwise" do
         http_request.auth.ssl.expects(:verify_mode=).never
+        new_wsdl_request.build
+      end
+    end
+
+    describe "ssl ciphers" do
+      it "is set when specified" do
+        globals.ssl_ciphers(ciphers)
+        http_request.auth.ssl.expects(:ciphers=).with(ciphers)
+
+        new_wsdl_request.build
+      end
+
+      it "is not set otherwise" do
+        http_request.auth.ssl.expects(:ciphers=).never
         new_wsdl_request.build
       end
     end
@@ -232,6 +247,7 @@ describe Savon::SOAPRequest do
 
   let(:globals)      { Savon::GlobalOptions.new }
   let(:http_request) { HTTPI::Request.new }
+  let(:ciphers)      { OpenSSL::Cipher.ciphers }
 
   def new_soap_request
     Savon::SOAPRequest.new(globals, http_request)
@@ -386,6 +402,20 @@ describe Savon::SOAPRequest do
 
       it "is not set otherwise" do
         http_request.auth.ssl.expects(:verify_mode=).never
+        new_soap_request.build
+      end
+    end
+
+    describe "ssl ciphers" do
+      it "is set when specified" do
+        globals.ssl_ciphers(ciphers)
+        http_request.auth.ssl.expects(:ciphers=).with(ciphers)
+
+        new_soap_request.build
+      end
+
+      it "is not set otherwise" do
+        http_request.auth.ssl.expects(:ciphers=).never
         new_soap_request.build
       end
     end


### PR DESCRIPTION
Useful in combination with:
- global option _ssl_version_
- https://github.com/savonrb/httpi/pull/180: _Implement HTTPI::Auth::SSL#ciphers configuration_

This allowed me to resolve following error:
`SSL_connect SYSCALL returned=5 errno=0 state=SSLv2/v3 read server hello A`