### PR TITLE
Fix a problem when http.body is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.11.2 (2017-03-13)
+* Fix: [#800](https://github.com/savonrb/savon/pull/800) Fix a problem when http.body is empty
+
 # 2.11.1 (2015-05-27)
 
 * Replace dependency on [uuid](https://rubygems.org/gems/uuid), using SecureRandom.uuid instead.

--- a/lib/savon/soap_fault.rb
+++ b/lib/savon/soap_fault.rb
@@ -27,7 +27,7 @@ module Savon
 
     def to_hash
       parsed = nori.parse(xml || http.body)
-      nori.find(parsed, 'Envelope', 'Body')
+      nori.find(parsed, 'Envelope', 'Body') || {}
     end
 
     private

--- a/spec/savon/soap_fault_spec.rb
+++ b/spec/savon/soap_fault_spec.rb
@@ -7,6 +7,7 @@ describe Savon::SOAPFault do
   let(:soap_fault_nc) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault)), nori_no_convert }
   let(:soap_fault_nc2) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault12)), nori_no_convert }
   let(:another_soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:another_soap_fault)), nori }
+  let(:soap_fault_no_body) { Savon::SOAPFault.new new_response(:body => {}), nori }
   let(:no_fault) { Savon::SOAPFault.new new_response, nori }
 
   let(:nori) { Nori.new(:strip_namespaces => true, :convert_tags_to => lambda { |tag| tag.snakecase.to_sym }) }
@@ -118,6 +119,10 @@ describe Savon::SOAPFault do
       }
 
       expect(soap_fault_nc2.to_hash).to eq(expected)
+    end
+
+    it "returns empty hash" do
+      expect(soap_fault_no_body.to_hash).to eq({})
     end
   end
 


### PR DESCRIPTION
When http.body is empty, `SOAPFault#to_s` raises error because `SOAPFault#to_hash` called by `SOAPFault#to_s` returns nil.

I think `#to_hash` should returns Hash rather than nil 🤔 