### PR TITLE
Fix bug with simpleType element and base attribute.

### DIFF
--- a/lib/savon/xs/types.rb
+++ b/lib/savon/xs/types.rb
@@ -91,10 +91,10 @@ class Savon
     class SimpleType < PrimaryType
 
       def base
-        child = @node.element_children.first
-        local = child.name.split(':').last
-
-        child['base'] if local == 'restriction'
+        @node.element_children.each { |child|
+          local = child.name.split(':').last
+          return child['base'] if local == 'restriction'
+        }
       end
 
     end


### PR DESCRIPTION
You can't get the "base" attribute of data when the  first child element name of the "simpleType" isn't "restriction" (we may have the "annotation" element before)

This attribute of the element (base_type) is then used in "Savon: XML::Element" to check whether the data is simpleType or complexType, resulting that a simpleType is considered a complexType.