### PR TITLE
Update options.rb to allow `proxy` to be `nil`.

### DIFF
--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -137,7 +137,7 @@ module Savon
 
     # Proxy server to use for all requests.
     def proxy(proxy)
-      @options[:proxy] = proxy
+      @options[:proxy] = proxy unless proxy.nil?
     end
 
     # A Hash of HTTP headers.


### PR DESCRIPTION
Allow `proxy` to be `nil` so the client can be instantiated like this:

```ruby
Savon.client(
    wsdl: 'some.wsdl',
    ...

    proxy: ENV['savon_proxy'].present? ? ENV['savon_proxy'] : nil
)
```