### PR TITLE
Fail correctly when SOAP envelope only contains a string

### DIFF
--- a/lib/savon/response.rb
+++ b/lib/savon/response.rb
@@ -69,7 +69,7 @@ module Savon
 
     def find(*path)
       envelope = nori.find(hash, 'Envelope')
-      raise_invalid_response_error! unless envelope
+      raise_invalid_response_error! unless envelope.is_a?(Hash)
 
       nori.find(envelope, *path)
     end

--- a/spec/fixtures/response/no_body.xml
+++ b/spec/fixtures/response/no_body.xml
@@ -1,0 +1,1 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">Text</soap:Envelope>

--- a/spec/savon/response_spec.rb
+++ b/spec/savon/response_spec.rb
@@ -235,6 +235,11 @@ describe Savon::Response do
       expect(result).to be_a(Hash)
       expect(result.keys).to include(:authentication_value)
     end
+
+    it 'fails correctly when envelope contains only string' do
+      response = soap_response({ :body => Fixture.response(:no_body) })
+      expect { response.find('Body') }.to raise_error Savon::InvalidResponseError
+    end
   end
 
   describe "#http" do


### PR DESCRIPTION
Fixes https://github.com/savonrb/savon/issues/773