### PR TITLE
Fix circular loading

### DIFF
--- a/lib/savon/soap_fault.rb
+++ b/lib/savon/soap_fault.rb
@@ -1,5 +1,3 @@
-require "savon"
-
 module Savon
   class SOAPFault < Error
 


### PR DESCRIPTION
* warning: loading in progress, circular require considered harmful - ruby-2.4.0/gems/savon-2.11.1/lib/savon.rb
* Loop: `savon.rb` -> `savon/client.rb` -> `savon/operation.rb` -> `savon/response.rb` -> `savon/soap_fault.rb` -> `savon.rb`