### PR TITLE
Added soap_action_prefix configuration

### DIFF
--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -123,7 +123,9 @@ module Savon
       # with no local option, but a wsdl, ask it for the soap_action
       soap_action ||= @wsdl.soap_action(@name.to_sym) if @wsdl.document?
       # if there is no soap_action up to this point, fallback to a simple default
-      soap_action ||= Gyoku.xml_tag(@name, :key_converter => @globals[:convert_request_keys_to])
+      action_name = Gyoku.xml_tag(@name, :key_converter => @globals[:convert_request_keys_to])
+      prefix = @globals[:soap_action_prefix] if @globals[:soap_action_prefix]
+      soap_action || "#{prefix}#{action_name}"
     end
 
     def endpoint

--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -91,7 +91,8 @@ module Savon
         :no_message_tag              => false,
         :follow_redirects            => false,
         :unwrap                      => false,
-        :host                        => nil
+        :host                        => nil,
+        :soap_action_prefix          => nil
       }
 
       options = defaults.merge(options)
@@ -342,6 +343,10 @@ module Savon
     # Instruct requests to follow HTTP redirects.
     def follow_redirects(follow_redirects)
       @options[:follow_redirects] = follow_redirects
+    end
+
+    def soap_action_prefix(prefix)
+      @options[:soap_action_prefix] = prefix
     end
   end
 

--- a/spec/savon/operation_spec.rb
+++ b/spec/savon/operation_spec.rb
@@ -155,14 +155,27 @@ describe Savon::Operation do
       expect(actual_soap_action).to eq('"http://taxcloud.net/VerifyAddress"')
     end
 
-    it "falls back to Gyoku if both option and WSDL are not available" do
-      globals.endpoint @server.url(:inspect_request)
+    context "when both option and WSDL are not available" do
+      it "falls back to Gyoku" do
+        globals.endpoint @server.url(:inspect_request)
 
-      operation = new_operation(:authenticate, no_wsdl, globals)
-      response  = operation.call
+        operation = new_operation(:authenticate, no_wsdl, globals)
+        response  = operation.call
 
-      actual_soap_action = inspect_request(response).soap_action
-      expect(actual_soap_action).to eq(%("authenticate"))
+        actual_soap_action = inspect_request(response).soap_action
+        expect(actual_soap_action).to eq(%("authenticate"))
+      end
+
+      it "prefixes the SOAP action with the soap_action_prefix" do
+        globals.endpoint @server.url(:inspect_request)
+        globals.soap_action_prefix "http://example.com/"
+
+        operation = new_operation(:authenticate, no_wsdl, globals)
+        response  = operation.call
+
+        actual_soap_action = inspect_request(response).soap_action
+        expect(actual_soap_action).to eq(%("http://example.com/authenticate"))
+      end
     end
 
     it "returns a Savon::Multipart::Response if available and requested globally" do


### PR DESCRIPTION
When a SOAP client is instanced using the `endpoint` and `namespace` attributes, there is no way to make the SOAP action an URI, except by providing a separate `soap_action` attribute manually on every invocation of the `.call` method. Hence, I'd like to introduce a new config variable `soap_action_prefix`, which will be prefixed to the soap action, if no soap_action was provided to the `.call` method, and when no WSDL file is used. I'm open to improvements or general discussion if this is a good / bad idea. 

Issue: https://github.com/savonrb/savon/issues/836

Thanks!