### PR TITLE
Added ssl_ca_path and ssl_cert_store to globals

### DIFF
--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -260,6 +260,15 @@ module Savon
       @options[:ssl_ca_cert] = cert
     end
 
+    # Sets the ca cert path.
+    def ssl_ca_cert_path(path)
+      @options[:ssl_ca_cert_path] = path
+    end
+
+    # Sets the ssl cert store.
+    def ssl_cert_store(store)
+      @options[:ssl_cert_store] = store
+    end
 
     # HTTP basic auth credentials.
     def basic_auth(*credentials)

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -28,11 +28,13 @@ module Savon
       @http_request.auth.ssl.verify_mode   = @globals[:ssl_verify_mode]   if @globals.include? :ssl_verify_mode
 
       @http_request.auth.ssl.cert_key_file = @globals[:ssl_cert_key_file] if @globals.include? :ssl_cert_key_file
-      @http_request.auth.ssl.cert_key      = @globals[:ssl_cert_key] if @globals.include? :ssl_cert_key
+      @http_request.auth.ssl.cert_key      = @globals[:ssl_cert_key]      if @globals.include? :ssl_cert_key
       @http_request.auth.ssl.cert_file     = @globals[:ssl_cert_file]     if @globals.include? :ssl_cert_file
-      @http_request.auth.ssl.cert          = @globals[:ssl_cert]     if @globals.include? :ssl_cert
+      @http_request.auth.ssl.cert          = @globals[:ssl_cert]          if @globals.include? :ssl_cert
       @http_request.auth.ssl.ca_cert_file  = @globals[:ssl_ca_cert_file]  if @globals.include? :ssl_ca_cert_file
-      @http_request.auth.ssl.ca_cert       = @globals[:ssl_ca_cert]  if @globals.include? :ssl_ca_cert
+      @http_request.auth.ssl.ca_cert_path  = @globals[:ssl_ca_cert_path]  if @globals.include? :ssl_ca_cert_path
+      @http_request.auth.ssl.ca_cert       = @globals[:ssl_ca_cert]       if @globals.include? :ssl_ca_cert
+      @http_request.auth.ssl.cert_store    = @globals[:ssl_cert_store]    if @globals.include? :ssl_cert_store
 
       @http_request.auth.ssl.cert_key_password = @globals[:ssl_cert_key_password] if @globals.include? :ssl_cert_key_password
     end

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -460,6 +460,26 @@ describe "Options" do
     end
   end
 
+  context "global :ssl_ca_cert_path" do
+    it "sets the ca cert path to use" do
+      ca_cert_path = "../../fixtures/ssl"
+      HTTPI::Auth::SSL.any_instance.expects(:ca_cert_path=).with(ca_cert_path).twice
+
+      client = new_client(:endpoint => @server.url, :ssl_ca_cert_path => ca_cert_path)
+      client.call(:authenticate)
+    end
+  end
+
+  context "global :ssl_ca_cert_store" do
+    it "sets the cert store to use" do
+      cert_store = OpenSSL::X509::Store.new
+      HTTPI::Auth::SSL.any_instance.expects(:cert_store=).with(cert_store).twice
+
+      client = new_client(:endpoint => @server.url, :ssl_cert_store => cert_store)
+      client.call(:authenticate)
+    end
+  end
+
   context "global :ssl_ca_cert" do
     it "sets the ca cert file to use" do
       ca_cert = File.open(File.expand_path("../../fixtures/ssl/client_cert.pem", __FILE__)).read


### PR DESCRIPTION
Needed to open this in favor of https://github.com/savonrb/savon/pull/735 , because I no longer have access there.

Some people might find it useful to use ca_cert path and cert store, like in Faraday