### PR TITLE
Travis: jruby-9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.2.4
   - 2.3.0
   - 2.4.1
-  - jruby-9.1.13.0
+  - jruby-9.1.15.0
   - rbx-2
 matrix:
   allow_failures:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html