### PR TITLE
 Add magic comment to freeze string literals

### DIFF
--- a/lib/savon.rb
+++ b/lib/savon.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Savon
 
   Error                 = Class.new(RuntimeError)

--- a/lib/savon/block_interface.rb
+++ b/lib/savon/block_interface.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Savon
   class BlockInterface
 

--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "savon/header"
 require "savon/message"
 require "nokogiri"

--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "savon/operation"
 require "savon/request"
 require "savon/options"

--- a/lib/savon/core_ext/string.rb
+++ b/lib/savon/core_ext/string.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module Savon
   module CoreExt

--- a/lib/savon/header.rb
+++ b/lib/savon/header.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "akami"
 require "gyoku"
 require "securerandom"

--- a/lib/savon/http_error.rb
+++ b/lib/savon/http_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "savon"
 
 module Savon

--- a/lib/savon/http_error.rb
+++ b/lib/savon/http_error.rb
@@ -15,7 +15,9 @@ module Savon
     attr_reader :http
 
     def to_s
-      "HTTP error (#{@http.code}): #{@http.body}" unless @http.body.empty?
+      String.new("HTTP error (#{@http.code})").tap do |str_error|
+        str_error << ": #{@http.body}" unless @http.body.empty?
+      end
     end
 
     def to_hash

--- a/lib/savon/http_error.rb
+++ b/lib/savon/http_error.rb
@@ -15,9 +15,7 @@ module Savon
     attr_reader :http
 
     def to_s
-      message = "HTTP error (#{@http.code})"
-      message << ": #{@http.body}" unless @http.body.empty?
-      message
+      "HTTP error (#{@http.code}): #{@http.body}" unless @http.body.empty?
     end
 
     def to_hash

--- a/lib/savon/log_message.rb
+++ b/lib/savon/log_message.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "nokogiri"
 
 module Savon

--- a/lib/savon/message.rb
+++ b/lib/savon/message.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "savon/qualified_message"
 require "gyoku"
 

--- a/lib/savon/mock.rb
+++ b/lib/savon/mock.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Savon
   class ExpectationError < StandardError; end
 end

--- a/lib/savon/mock/expectation.rb
+++ b/lib/savon/mock/expectation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "httpi"
 
 module Savon

--- a/lib/savon/mock/spec_helper.rb
+++ b/lib/savon/mock/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "savon/mock"
 
 module Savon

--- a/lib/savon/model.rb
+++ b/lib/savon/model.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Savon
   module Model
 

--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "savon/options"
 require "savon/block_interface"
 require "savon/request"

--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "logger"
 require "httpi"
 

--- a/lib/savon/qualified_message.rb
+++ b/lib/savon/qualified_message.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "gyoku"
 
 module Savon

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "httpi"
 
 module Savon

--- a/lib/savon/request_logger.rb
+++ b/lib/savon/request_logger.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "savon/log_message"
 
 module Savon

--- a/lib/savon/response.rb
+++ b/lib/savon/response.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "nori"
 require "savon/soap_fault"
 require "savon/http_error"

--- a/lib/savon/soap_fault.rb
+++ b/lib/savon/soap_fault.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Savon
   class SOAPFault < Error
 

--- a/lib/savon/version.rb
+++ b/lib/savon/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Savon
   VERSION = '2.12.0'
 end

--- a/spec/integration/centra_spec.rb
+++ b/spec/integration/centra_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 module LogInterceptor

--- a/spec/integration/email_example_spec.rb
+++ b/spec/integration/email_example_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
  require "spec_helper"
 
 describe "Email example" do

--- a/spec/integration/random_quote_spec.rb
+++ b/spec/integration/random_quote_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'rpc/encoded binding test' do

--- a/spec/integration/ratp_example_spec.rb
+++ b/spec/integration/ratp_example_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
  require "spec_helper"
 
 describe "RATP example" do

--- a/spec/integration/stockquote_example_spec.rb
+++ b/spec/integration/stockquote_example_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
  require "spec_helper"
 
 describe "Stockquote example" do

--- a/spec/integration/support/application.rb
+++ b/spec/integration/support/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rack"
 require "json"
 

--- a/spec/integration/support/server.rb
+++ b/spec/integration/support/server.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "puma"
 require "puma/minissl"
 

--- a/spec/integration/temperature_example_spec.rb
+++ b/spec/integration/temperature_example_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
  require "spec_helper"
 
 describe "Temperature example" do

--- a/spec/integration/zipcode_example_spec.rb
+++ b/spec/integration/zipcode_example_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
  require "spec_helper"
 
 describe "ZIP code example" do

--- a/spec/savon/builder_spec.rb
+++ b/spec/savon/builder_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Savon::Builder do

--- a/spec/savon/client_spec.rb
+++ b/spec/savon/client_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "integration/support/server"
 

--- a/spec/savon/core_ext/string_spec.rb
+++ b/spec/savon/core_ext/string_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe String do

--- a/spec/savon/features/message_tag_spec.rb
+++ b/spec/savon/features/message_tag_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Savon do

--- a/spec/savon/http_error_spec.rb
+++ b/spec/savon/http_error_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Savon::HTTPError do

--- a/spec/savon/http_error_spec.rb
+++ b/spec/savon/http_error_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 
 describe Savon::HTTPError do
   let(:http_error) { Savon::HTTPError.new new_response(:code => 404, :body => "Not Found") }
+  let(:http_error_with_empty_body) { Savon::HTTPError.new new_response(:code => 404, :body => "") }
   let(:no_error) { Savon::HTTPError.new new_response }
 
   it "inherits from Savon::Error" do
@@ -30,6 +31,12 @@ describe Savon::HTTPError do
     describe "##{method}" do
       it "returns the HTTP error message" do
         expect(http_error.send method).to eq("HTTP error (404): Not Found")
+      end
+
+      context "when the body is empty" do
+        it "returns the HTTP error without the body message" do
+          expect(http_error_with_empty_body.send method).to eq("HTTP error (404)")
+        end
       end
     end
   end

--- a/spec/savon/log_message_spec.rb
+++ b/spec/savon/log_message_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Savon::LogMessage do

--- a/spec/savon/message_spec.rb
+++ b/spec/savon/message_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "integration/support/server"
 

--- a/spec/savon/mock_spec.rb
+++ b/spec/savon/mock_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "savon/mock/spec_helper"
 

--- a/spec/savon/model_spec.rb
+++ b/spec/savon/model_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "integration/support/server"
 

--- a/spec/savon/observers_spec.rb
+++ b/spec/savon/observers_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "integration/support/server"
 

--- a/spec/savon/operation_spec.rb
+++ b/spec/savon/operation_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "integration/support/server"
 require "json"

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "integration/support/server"
 require "json"

--- a/spec/savon/qualified_message_spec.rb
+++ b/spec/savon/qualified_message_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 module Savon

--- a/spec/savon/request_logger_spec.rb
+++ b/spec/savon/request_logger_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Savon::RequestLogger do

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 require "integration/support/server"
 

--- a/spec/savon/response_spec.rb
+++ b/spec/savon/response_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Savon::Response do

--- a/spec/savon/soap_fault_spec.rb
+++ b/spec/savon/soap_fault_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Savon::SOAPFault do

--- a/spec/savon/softlayer_spec.rb
+++ b/spec/savon/softlayer_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Savon::Builder do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler"
 Bundler.setup(:default, :development)
 

--- a/spec/support/adapters.rb
+++ b/spec/support/adapters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'httpi/adapter/httpclient'
 
 # Proxy adapter. Records all requests and passes them to HTTPClient

--- a/spec/support/endpoint.rb
+++ b/spec/support/endpoint.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Endpoint
   class << self
 

--- a/spec/support/fixture.rb
+++ b/spec/support/fixture.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Fixture
 
   TYPES = { :gzip => "gz", :response => "xml", :wsdl => "xml" }

--- a/spec/support/integration.rb
+++ b/spec/support/integration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SpecSupport
 
   def call_and_fail_gracefully(client, *args, &block)

--- a/spec/support/stdout.rb
+++ b/spec/support/stdout.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SpecSupport
 
   def mock_stdout


### PR DESCRIPTION
Because frozen string literals [will be the default in Ruby 3.0](https://bugs.ruby-lang.org/issues/8976).