### PR TITLE
Fix: Remove xmlns:wsa's already added elsewhere; select Content-Type HTTP header based on SOAP version

### DIFF
--- a/lib/savon/header.rb
+++ b/lib/savon/header.rb
@@ -62,13 +62,8 @@ module Savon
        convert_to_xml({
          'wsa:Action' => @locals[:soap_action],
          'wsa:To' => @globals[:endpoint],
-         'wsa:MessageID' => "urn:uuid:#{SecureRandom.uuid}",
-         attributes!: {
-          'wsa:MessageID' => {
-            "xmlns:wsa" => "http://schemas.xmlsoap.org/ws/2004/08/addressing"
-          }
-         }
-       })
+         'wsa:MessageID' => "urn:uuid:#{SecureRandom.uuid}"
+                      })
     end
 
     def convert_to_xml(hash_or_string)

--- a/lib/savon/header.rb
+++ b/lib/savon/header.rb
@@ -63,7 +63,7 @@ module Savon
          'wsa:Action' => @locals[:soap_action],
          'wsa:To' => @globals[:endpoint],
          'wsa:MessageID' => "urn:uuid:#{SecureRandom.uuid}"
-                      })
+       })
     end
 
     def convert_to_xml(hash_or_string)

--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -95,15 +95,18 @@ module Savon
       request.url = endpoint
       request.body = builder.to_s
 
+      if builder.multipart
+        request.gzip
+        request.headers["Content-Type"] = ["multipart/related",
+                                           "type=\"application/soap+xml\"",
+                                           "start=\"#{builder.multipart[:start]}\"",
+                                           "boundary=\"#{builder.multipart[:multipart_boundary]}\""].join("; ")
+        request.headers["MIME-Version"] = "1.0"
+      end
+
       # TODO: could HTTPI do this automatically in case the header
       #       was not specified manually? [dh, 2013-01-04]
       request.headers["Content-Length"] = request.body.bytesize.to_s
-
-      if builder.multipart
-        request.headers["Content-Type"] = "multipart/related; " \
-          "boundary=\"#{builder.multipart[:multipart_boundary]}\"; " \
-          "type=\"text/xml\"; start=\"#{builder.multipart[:start]}\""
-      end
 
       request
     end

--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -11,6 +11,11 @@ require "mail"
 module Savon
   class Operation
 
+    SOAP_REQUEST_TYPE = {
+      1 => "text/xml",
+      2 => "application/soap+xml"
+    }
+
     def self.create(operation_name, wsdl, globals)
       if wsdl.document?
         ensure_name_is_symbol! operation_name
@@ -98,7 +103,7 @@ module Savon
       if builder.multipart
         request.gzip
         request.headers["Content-Type"] = ["multipart/related",
-                                           "type=\"application/soap+xml\"",
+                                           "type=\"#{SOAP_REQUEST_TYPE[@globals[:soap_version]]}\"",
                                            "start=\"#{builder.multipart[:start]}\"",
                                            "boundary=\"#{builder.multipart[:multipart_boundary]}\""].join("; ")
         request.headers["MIME-Version"] = "1.0"

--- a/spec/savon/message_spec.rb
+++ b/spec/savon/message_spec.rb
@@ -56,16 +56,6 @@ describe Savon::Message do
         end
       end
     end
-
-    context 'wsa:MessageID' do
-      let(:message_id_tag) {
-        '<wsa:MessageID xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">'
-      }
-      it 'should include xmlns:wsa attribute' do
-        response = client.call(:something, message: {})
-        expect(response.xml).to include(message_id_tag)
-      end
-    end
   end
 
 end


### PR DESCRIPTION
Couple of changes I needed for multipart support to work with a server using Axis2.

I'm having a little trouble running the test suite on my system, but I'll work on that.