### PR TITLE
Fix detecting Soap 1.1 Fault when faultcode or faultstring are empty

### DIFF
--- a/lib/savon/soap_fault.rb
+++ b/lib/savon/soap_fault.rb
@@ -5,7 +5,7 @@ module Savon
     def self.present?(http, xml = nil)
       xml ||= http.body
       fault_node  = xml.include?("Fault>")
-      soap1_fault = xml.include?("faultcode>") && xml.include?("faultstring>")
+      soap1_fault = xml.match(/faultcode\/?\>/) && xml.match(/faultstring\/?\>/)
       soap2_fault = xml.include?("Code>") && xml.include?("Reason>")
 
       fault_node && (soap1_fault || soap2_fault)

--- a/spec/fixtures/response/empty_soap_fault.xml
+++ b/spec/fixtures/response/empty_soap_fault.xml
@@ -1,0 +1,13 @@
+<SOAP-ENV:Envelope SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <SOAP-ENV:Body>
+    <SOAP-ENV:Fault>
+      <faultcode/>
+      <faultstring/>
+      <detail><soapVal><ERRNO xsi:type="xsd:string">80:1289245853:55</ERRNO></soapVal></detail>
+    </SOAP-ENV:Fault>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/spec/savon/soap_fault_spec.rb
+++ b/spec/savon/soap_fault_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 
 describe Savon::SOAPFault do
   let(:soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault)), nori }
+  let(:empty_soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:empty_soap_fault)), nori }
   let(:soap_fault2) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault12)), nori }
   let(:soap_fault_funky) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault_funky)), nori }
   let(:soap_fault_nc) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault)), nori_no_convert }
@@ -30,6 +31,11 @@ describe Savon::SOAPFault do
       expect(Savon::SOAPFault.present? http).to be_truthy
     end
 
+    it "returns true if the HTTP response contains a SOAP 1.1 fault with empty fault tags" do
+      http = new_response(:body => Fixture.response(:empty_soap_fault))
+      expect(Savon::SOAPFault.present? http).to be_truthy
+    end
+
     it "returns true if the HTTP response contains a SOAP 1.2 fault" do
       http = new_response(:body => Fixture.response(:soap_fault12))
       expect(Savon::SOAPFault.present? http).to be_truthy
@@ -49,6 +55,10 @@ describe Savon::SOAPFault do
     describe "##{method}" do
       it "returns a SOAP 1.1 fault message" do
         expect(soap_fault.send method).to eq("(soap:Server) Fault occurred while processing.")
+      end
+
+      it "returns an empty fault message" do
+        expect(empty_soap_fault.send method).to eq(nil)
       end
 
       it "returns a SOAP 1.2 fault message" do


### PR DESCRIPTION
**What kind of change is this?**
Bugfix

**Did you add tests for your changes?**
Added tests to check for any type of `faultcode` and `faultstring` tags(empty or not)

**Summary of changes**

Sometimes I receive responses with empty faultstring/faultcode tags(example below). 
Savon wrongly thinks that this is an `HTTPError`, even though I got an SOAP xml response.
```xml
<?xml version="1.0" encoding="UTF-8"?> 
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
<soap:Body xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
<soap:Fault>
    <faultcode xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">soap-env:Server</faultcode>
    <faultstring/>
    <faultactor/>
    <detail>
        <entityNotFoundFault xmlns="http://api.vetrf.ru/schema/cdm/base/ws-definitions" xmlns:bs="http://api.vetrf.ru/schema/cdm/base" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"> 
            <bs:message>****</bs:message> 
        </entityNotFoundFault>
    </detail>
</soap:Fault>
</soap:Body>
</soapenv:Envelope>
```