### PR TITLE
extend invalid response error to expose HTTP response object

### DIFF
--- a/lib/savon.rb
+++ b/lib/savon.rb
@@ -5,7 +5,6 @@ module Savon
   InitializationError   = Class.new(Error)
   UnknownOptionError    = Class.new(Error)
   UnknownOperationError = Class.new(Error)
-  InvalidResponseError  = Class.new(Error)
 
   def self.client(globals = {}, &block)
     Client.new(globals, &block)

--- a/lib/savon/invalid_response_error.rb
+++ b/lib/savon/invalid_response_error.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require "savon"
+
+module Savon
+  class InvalidResponseError < Error
+    attr_reader :http, :xml
+
+    def initialize(http, xml)
+      @http, @xml = http, xml
+    end
+
+    def to_s
+      "Unable to parse response body:\n" + xml.inspect
+    end
+  end
+end

--- a/lib/savon/response.rb
+++ b/lib/savon/response.rb
@@ -2,6 +2,7 @@
 require "nori"
 require "savon/soap_fault"
 require "savon/http_error"
+require "savon/invalid_response_error"
 
 module Savon
   class Response
@@ -134,7 +135,7 @@ module Savon
     end
 
     def raise_invalid_response_error!
-      raise InvalidResponseError, "Unable to parse response body:\n" + xml.inspect
+      raise InvalidResponseError.new(@http, xml)
     end
 
     def xml_namespaces

--- a/spec/savon/invalid_response_error_spec.rb
+++ b/spec/savon/invalid_response_error_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Savon::InvalidResponseError do
+  let(:invalid_response_error) do
+    Savon::InvalidResponseError.new(http_response, xml)
+  end
+  let(:http_response) { new_response(code: 200, body: 'invalid xml body') }
+  let(:xml)           { 'invalid xml body' }
+  let(:error_message) { "Unable to parse response body:\n\"invalid xml body\"" }
+
+  it 'inherits from Savon::Error' do
+    expect(Savon::InvalidResponseError.ancestors).to include(Savon::Error)
+  end
+
+  describe '#http' do
+    it 'returns the HTTPI::Response' do
+      expect(invalid_response_error.http).to be_a(HTTPI::Response)
+    end
+  end
+
+  describe '#xml' do
+    it 'returns the xml body' do
+      expect(invalid_response_error.xml).to eq xml
+    end
+  end
+
+  %i(message to_s).each do |method|
+    describe "##{method}" do
+      it 'returns the specified error message' do
+        expect(invalid_response_error.send(method)).to eq(error_message)
+      end
+
+      context 'when the xml variable is different' do
+        let(:xml)           { 'different than body' }
+        let(:error_message) { "Unable to parse response body:\n\"different than body\"" }
+
+        it 'returns the error message with the xml string' do
+          expect(invalid_response_error.send(method)).to eq(error_message)
+        end
+      end
+    end
+  end
+
+  def new_response(options = {})
+    defaults = { code: 200, headers: {}, body: Fixture.response(:authentication) }
+    response = defaults.merge options
+
+    HTTPI::Response.new response[:code], response[:headers], response[:body]
+  end
+end

--- a/spec/savon/response_spec.rb
+++ b/spec/savon/response_spec.rb
@@ -130,7 +130,11 @@ describe Savon::Response do
     end
 
     it "should throw an exception when the response header isn't parsable" do
-      expect { invalid_soap_response.header }.to raise_error Savon::InvalidResponseError
+      expect { invalid_soap_response.header }.to raise_error { |error|
+        expect(error).to be_a(Savon::InvalidResponseError)
+        expect(error.http).to be_a(HTTPI::Response)
+        expect(error.xml).to eq(invalid_soap_response.xml)
+      }
     end
   end
 
@@ -239,7 +243,11 @@ describe Savon::Response do
 
     it 'fails correctly when envelope contains only string' do
       response = soap_response({ :body => Fixture.response(:no_body) })
-      expect { response.find('Body') }.to raise_error Savon::InvalidResponseError
+      expect { response.find('Body') }.to raise_error { |error|
+        expect(error).to be_a(Savon::InvalidResponseError)
+        expect(error.http).to be_a(HTTPI::Response)
+        expect(error.xml).to eq(response.xml)
+      }
     end
   end
 


### PR DESCRIPTION
**What kind of change is this?**

Feature

**Did you add tests for your changes?**

Yes

**Summary of changes:**

Extend `Savon::InvalidResponseError` to expose the HTTP response object. 

**Why?** 

To be able to track invalid response errors raw HTTP responses for comprehensive, and actionable error reporting.

**Would this introduce a breaking change?**

**No**, the error class is the same `Savon::InvalidResponseError `. Likewise, the error message is backward compatible and not changed. The change only extends the error class instantiating the new instance variables `http` and `xml` making them directly accessible via calling `error.xml` or `error.http`.

**Example:** 

```ruby
begin 
  response = client.call(OPERATION_NAME, message: some_message)
rescue Savon::InvalidResponseError => e
  log_error_response(e.http)
end
```