### PR TITLE
Feature streamed call on client to get chunked response

### DIFF
--- a/lib/savon/client.rb
+++ b/lib/savon/client.rb
@@ -37,6 +37,10 @@ module Savon
       operation(operation_name).call(locals, &block)
     end
 
+    def streamed_call(operation_name, locals = {}, &block)
+      operation(operation_name).streamed_call(locals, &block)
+    end
+
     def service_name
       raise_missing_wsdl_error! unless @wsdl.document?
       @wsdl.service_name

--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -60,6 +60,19 @@ module Savon
       create_response(response)
     end
 
+    def streamed_call(locals = {}, &block)
+      builder = build(locals)
+
+      response = Savon.notify_observers(@name, builder, @globals, @locals)
+      request = build_request(builder)
+      request.on_body(&block) # block is used for on_body callback
+      response ||= call_with_logging request
+
+      raise_expected_httpi_response! unless response.kind_of?(HTTPI::Response)
+
+      create_response(response)
+    end
+
     def request(locals = {}, &block)
       builder = build(locals, &block)
       build_request(builder)

--- a/spec/integration/country_information_example.rb
+++ b/spec/integration/country_information_example.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "Country Information Example" do
-  it "retrieves information about all countries using streamed response" do
+  it "supports a streamed response where chunks are passed in a block" do
     client = Savon.client(
       :wsdl => "http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso?WSDL",
       :read_timeout => 10,
@@ -9,13 +9,14 @@ describe "Country Information Example" do
       :log => false
     )
 
-    response = ""
+    body = ""
     chunk_counter = 0
-    result = client.streamed_call(:full_country_info_all_countries) do |data|
+    response = client.streamed_call(:full_country_info_all_countries) do |data|
       chunk_counter += 1
-      response += data
+      body += data
     end
-    expect(response.size).to_not eql(0)
+    expect(body.size).to_not eql(0)
     expect(chunk_counter).to_not eql(0)
+    expect(response.http.body).to eql("")
   end
 end

--- a/spec/integration/country_information_example.rb
+++ b/spec/integration/country_information_example.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe "Country Information Example" do
+  it "retrieves information about all countries using streamed response" do
+    client = Savon.client(
+      :wsdl => "http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso?WSDL",
+      :read_timeout => 10,
+      :open_timeout => 10,
+      :log => false
+    )
+
+    response = ""
+    chunk_counter = 0
+    result = client.streamed_call(:full_country_info_all_countries) do |data|
+      chunk_counter += 1
+      response += data
+    end
+    expect(response.size).to_not eql(0)
+    expect(chunk_counter).to_not eql(0)
+  end
+end


### PR DESCRIPTION
**Feature**

New method for savon client `streamed_call` to get the response as chunks of data using httpi's request `on_body` feature. `streamed_call` receives a block where the chunk is passed.
 
**Tests**

I added an integration test performing a example request. I'll add unit tests as soon as possible, but we have issues mocking the response to get chunks, we're getting the whole response data instead.

**Information**

@faelsoto and I  have been working in consuming a web service that encodes a zip file with base64 and return it as part of the result in the xml. The file size is up to ~30MB or more. This is how we try to solve this problem to obtain the response as a stream.


@faelsoto opened #884 to discuss how available is to make it work. As a workaround we made this changes, but with your help we can make it more stable.