### PR TITLE
Add Ruby 2.5.3 to TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script: "bundle exec rake --trace"
 rvm:
   - 2.3.0
   - 2.4.1
+  - 2.5.3
   - jruby-9.1.15.0
   - rbx-2
 matrix:


### PR DESCRIPTION
**What kind of change is this?**

Add Ruby 2.5.3 to the TravisCI config so that the build runs the tests against the latest version of Ruby, which it should do given that the README says that MRI 2.5 is supported.

**Did you add tests for your changes?**

No need to add tests.

**Summary of changes**

Simple addition of Ruby 2.5.3 to the `.travis.yml` file.