### PR TITLE
Gemspec: drop deprecated rubyforge_project

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.required_ruby_version = '>= 1.9.2'
 
-  s.rubyforge_project = s.name
   s.license = 'MIT'
 
   s.add_dependency "nori",     "~> 2.4"


### PR DESCRIPTION
Clean up deprecated-and-ignored property `rubyforge_project` from gemspec.

**Did you add tests for your changes?**

No, this change has no replacement.

**Summary of changes**

The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436

