### PR TITLE
CI: Drop unused directive sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # https://github.com/travis-ci/travis-ci/wiki/.travis.yml-options
 language: "ruby"
-sudo: false
 before_install:
   - gem install bundler
 script: "bundle exec rake --trace"


### PR DESCRIPTION
**What kind of change is this?**

This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).


**Did you add tests for your changes?**

No.

