### PR TITLE
Copy the TravisCI config from Puma server itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - 2.3.0
   - 2.4.1
   - 2.5.3
-  - jruby-9.1.15.0
   - rbx-2
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,8 @@ matrix:
   allow_failures:
     - rvm: rbx-2
   fast_finish: true
+  include:
+    - rvm: jruby-9.2.8.0
+      env: JRUBY_OPTS="--debug" JAVA_OPTS="--add-opens java.base/sun.nio.ch=org.jruby.dist --add-opens java.base/java.io=org.jruby.dist --add-opens java.base/java.util.zip=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED"
 notifications:
   irc: "irc.freenode.org#savon"


### PR DESCRIPTION
**What kind of change is this?**

Bug fix for Puma not starting in tests

**Did you add tests for your changes?**

No... but this should fix existing test failures.

**Summary of changes**

There appears to be an existing bug here:

https://github.com/savonrb/savon/pull/912
```
  1) Options global: endpoint and namespace sets the SOAP endpoint to use to allow requests without a WSDL document
419     Failure/Error: @server = IntegrationServer.run
420     LoadError:
421       load error: puma/java_io_buffer -- java.lang.reflect.InaccessibleObjectException: Unable to make field protected byte[] java.io.ByteArrayOutputStream.buf accessible: module java.base does not "opens java.io" to module jruby
422     # ./spec/integration/support/server.rb:1:in `(root)'
423     # ./spec/integration/support/server.rb:31:in `block in initialize'
424     # ./spec/integration/support/server.rb:10:in `run'
425     # ./spec/savon/options_spec.rb:11:in `(root)'
```
https://travis-ci.org/savonrb/savon/jobs/580376246

**Other information**

https://github.com/puma/puma/blob/3b706288f01bb09e626be441e0546c188c623986/.travis.yml#L56-L57