### PR TITLE
Fix elementFormDefault="qualified" regression

### DIFF
--- a/lib/savon/qualified_message.rb
+++ b/lib/savon/qualified_message.rb
@@ -27,7 +27,7 @@ module Savon
             translated_key  = translate_tag(key)
             newkey          = add_namespaces_to_values(key, path).first
             newpath         = path + [translated_key]
-            newhash[newkey] = to_hash(value, newpath)
+            newhash[newkey] = to_hash(value, @types[newpath] ? [@types[newpath]] : newpath)
           end
         end
         newhash

--- a/spec/fixtures/wsdl/elements_in_types.xml
+++ b/spec/fixtures/wsdl/elements_in_types.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions xmlns:tm="http://microsoft.com/wsdl/mime/textMatching/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:tns="www.example.com/XML" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:s1="http://microsoft.com/wsdl/types/" xmlns:s="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" targetNamespace="www.example.com/XML" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+  <wsdl:types>
+    <s:schema elementFormDefault="qualified" targetNamespace="www.example.com/XML">
+      <s:complexType name="Transaction" abstract="true">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Qualified" type="s:string" />
+        </s:sequence>
+      </s:complexType>
+      <s:complexType name="TopLevelTransaction">
+        <s:complexContent mixed="false">
+          <s:extension base="tns:Transaction">
+          </s:extension>
+        </s:complexContent>
+      </s:complexType>
+      <s:element name="TopLevelTransaction">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="TopLevelTransaction" type="tns:TopLevelTransaction" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
+    </s:schema>
+  </wsdl:types>
+  <wsdl:message name="TopLevelTransactionSoapIn">
+    <wsdl:part name="parameters" element="tns:TopLevelTransaction" />
+  </wsdl:message>
+  <wsdl:portType name="XMLTESoap">
+    <wsdl:operation name="TopLevelTransaction">
+      <wsdl:documentation xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">TopLevelTransaction.</wsdl:documentation>
+      <wsdl:input message="tns:TopLevelTransactionSoapIn" />
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="XMLTESoap12" type="tns:XMLTESoap">
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <wsdl:operation name="TopLevelTransaction">
+      <soap12:operation soapAction="www.example.com/XML/TopLevelTransaction" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+    </wsdl:operation>
+  </wsdl:binding>
+</wsdl:definitions>

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -220,6 +220,17 @@ describe "Options" do
       expect(response.http.body).to include("<user>lea</user>")
       expect(response.http.body).to include("<password>top-secret</password>")
     end
+
+    it "qualifies elements embedded in complex types" do
+      client = new_client(:endpoint => @server.url(:repeat),
+                          :wsdl => Fixture.wsdl(:elements_in_types))
+      msg = {":TopLevelTransaction"=>{":Qualified"=>"A Value"}}
+
+      response = client.call(:top_level_transaction, :message => msg)
+
+      expect(response.http.body.scan(/<tns:Qualified>/).count).to eq(1)
+    end
+
   end
 
   context "global :env_namespace" do


### PR DESCRIPTION
Types were not properly qualified

**What kind of change is this?**

Bugfix

**Did you add tests for your changes?**

Yes. I've now added a breaking test which ensures the message is properly encoded.

**Summary of changes**

This fixes a bug raised in #916. This means more recent versions of Savon do not work properly in certain specific circumstances when elements are embedded in types.

**Other information**

The test is based on a real-world wsdl file in which messages are being incorrectly "qualified".