### PR TITLE
Allow the write timeout option to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-* Feature: [#930](https://github.com/savonrb/savon/pull/930) Add options for SSL min_version/max_version support 
 * Fix: [#868](https://github.com/savonrb/savon/pull/868) Remove `xmlns:wsa`'s already added elsewhere; select Content-Type HTTP header based on SOAP version.
+* Feature: [#920](https://github.com/savonrb/savon/pull/920) Add a `write_timeout` setter for HTTP requests
+* Feature: [#930](https://github.com/savonrb/savon/pull/930) Add options for SSL min_version/max_version support
 * Add your PR changelog line here
 
 ## 2.12.1 (2020-07-05)

--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -156,6 +156,11 @@ module Savon
       @options[:read_timeout] = read_timeout
     end
 
+    # Write timeout in seconds.
+    def write_timeout(write_timeout)
+      @options[:write_timeout] = write_timeout
+    end
+
     # The encoding to use. Defaults to "UTF-8".
     def encoding(encoding)
       @options[:encoding] = encoding

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -22,6 +22,7 @@ module Savon
     def configure_timeouts
       @http_request.open_timeout = @globals[:open_timeout] if @globals.include? :open_timeout
       @http_request.read_timeout = @globals[:read_timeout] if @globals.include? :read_timeout
+      @http_request.write_timeout = @globals[:write_timeout] if @globals.include? :write_timeout
     end
 
     def configure_ssl

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -74,6 +74,20 @@ describe Savon::WSDLRequest do
       end
     end
 
+    describe "write timeout" do
+      it "is set when specified" do
+        globals.write_timeout(44)
+        http_request.expects(:write_timeout=).with(44)
+
+        new_wsdl_request.build
+      end
+
+      it "is not set otherwise" do
+        http_request.expects(:read_timeout=).never
+        new_wsdl_request.build
+      end
+    end
+
     describe "ssl version" do
       it "is set when specified" do
         globals.ssl_version(:TLSv1)


### PR DESCRIPTION
**What kind of change is this?**
Feature

**Summary of changes**
Fixes #834 Supports write_timeout option.
Write timeout is supported by HTTPI but not by Savon.

**Other information**
While not having the setting is limiting, it can also cause issues in
adapters. For example, when setting timeouts per operation in HTTP, any
timeouts not supplied will be set to 0.25 seconds which can lead to
unexpected surprises for users