### PR TITLE
CI: Travis maintenance: add JRuby 9.2; fix JRuby 9.1 build; configure Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - 2.3.0
   - 2.4.1
   - 2.5.3
-  - rbx-4
 
 matrix:
   include:
@@ -17,6 +16,8 @@ matrix:
       jdk: openjdk8
     - rvm: jruby-9.2.11.1
       jdk: openjdk11
+    - rvm: rbx-4
+      dist: trusty
   allow_failures:
     - rvm: rbx-4
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,19 @@ rvm:
 
 matrix:
   include:
-    - rvm: jruby-9.1.17.0
+    - name: JRuby 9.1
+      rvm: jruby-9.1.17.0
       jdk: openjdk8
-    - rvm: jruby-9.2.11.1
+    - name: JRuby 9.2
+      rvm: jruby-9.2.11.1
       jdk: openjdk11
       env: JAVA_OPTS="--add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED"
-    - rvm: rbx-4
+    - name: Rubinius
+      rvm: rbx-4
       dist: trusty
   allow_failures:
-    - rvm: rbx-4
+    - name: Rubinius
+    - name: JRuby 9.2
   fast_finish: true
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       jdk: openjdk8
     - rvm: jruby-9.2.11.1
       jdk: openjdk11
+      env: JAVA_OPTS="--add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED"
     - rvm: rbx-4
       dist: trusty
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,13 @@ before_install:
 script: "bundle exec rake --trace"
 
 rvm:
-  - 2.3.0
-  - 2.4.1
-  - 2.5.3
+  - "2.5"
+  - "2.6"
+  - "2.7"
 
 matrix:
   include:
-    - name: JRuby 9.1
-      rvm: jruby-9.1.17.0
-      jdk: openjdk8
-    - name: JRuby 9.2
+    - name: "JRuby 9.2"
       rvm: jruby-9.2.11.1
       jdk: openjdk11
       env: JAVA_OPTS="--add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED"
@@ -24,7 +21,7 @@ matrix:
       dist: trusty
   allow_failures:
     - name: Rubinius
-    - name: JRuby 9.2
+    - name: "JRuby 9.2"
   fast_finish: true
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,25 @@
 # https://github.com/travis-ci/travis-ci/wiki/.travis.yml-options
 language: "ruby"
-sudo: false
+
 before_install:
   - gem install bundler
 script: "bundle exec rake --trace"
+
 rvm:
   - 2.3.0
   - 2.4.1
   - 2.5.3
-  - jruby-9.1.15.0
-  - rbx-2
+  - rbx-4
+
 matrix:
+  include:
+    - rvm: jruby-9.1.17.0
+      jdk: openjdk8
+    - rvm: jruby-9.2.11.1
+      jdk: openjdk11
   allow_failures:
-    - rvm: rbx-2
+    - rvm: rbx-4
   fast_finish: true
+
 notifications:
   irc: "irc.freenode.org#savon"


### PR DESCRIPTION
This is a CI change to use latest release of JRuby 9.1 (which is a 2.3, now out of support, [see Ruby's support policy](https://www.ruby-lang.org/en/downloads/branches/)).

**Did you add tests for your changes?**

No, no new tests were added - this is a CI-only change.

**Summary of changes**

The attempt is: try to make the JRuby build pass.

- JRuby 9.1 (the existing one) now passes ✅ 
- JRuby 9.2 (added) has 1 test failure: I will put this in the `allow_failures` ⚠️  for now
>   1) Savon::WSDLRequest#build ssl encrypted cert key file set with an invalid decrypting password fails when attempting to use the SSL private key
     Failure/Error: expect { http_request.auth.ssl.cert_key }.to raise_error
       expected Exception but nothing was raised
     # ./spec/savon/request_spec.rb:162:in `block in <main>'
- Rubinius 4 on Trusty installs, which is progress, but it times out during the Bundle install phase (kept in `allow_failures` ⚠️)

Closes #910 by including its fix here.