### PR TITLE
gemspec: Formally support Ruby 2.5.0 and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ For more examples, you should check out the
 [integration tests](https://github.com/savonrb/savon/tree/version2/spec/integration).
 
 ## Ruby version support
+
+* `master` - MRI 2.5, 2.6, 2.7 (same support as Ruby)
 * 2.12.x - MRI 2.2, 2.3, 2.4, 2.5
 * 2.11.x - MRI 2.0, 2.1, 2.2, and 2.3
 

--- a/savon.gemspec
+++ b/savon.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://savonrb.com"
   s.summary     = "Heavy metal SOAP client"
   s.description = s.summary
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.license = 'MIT'
 


### PR DESCRIPTION
**What kind of change is this?**

This PR changes the gemspec's promise of support to only include Ruby versions which are in support.

In #921, this change was suggested and accepted.

**Did you add tests for your changes?**

No tests were changed.

**Summary of changes**

Versions below Ruby 2.5 no longer get any security updates.

Ruby 2.5: EOL date: 2021-03-31.

**Other information**

Ruby maintenance branches and schedule for end-of-life: https://www.ruby-lang.org/en/downloads/branches/
