### PR TITLE
fix circular loading from http_error

### DIFF
--- a/lib/savon/http_error.rb
+++ b/lib/savon/http_error.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "savon"
 
 module Savon
   class HTTPError < Error


### PR DESCRIPTION
**What kind of change is this?**

Fix warning in current version
```
warning: loading in progress, circular require considered harmful - ruby-2.6.5/gems/savon-2.12.0/lib/savon.rb

savon.rb -> savon/client.rb -> savon/operation.rb -> savon/response.rb -> savon/http_error.rb -> savon.rb
```

**Did you add tests for your changes?**

I don't think is necessary add an extra test for this change

**Summary of changes**

Remove circular loading caused by requiere savon in `savon/http_error`
