### PR TITLE
CI: Use JRuby 9.2.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 # https://github.com/travis-ci/travis-ci/wiki/.travis.yml-options
 language: "ruby"
 
-before_install:
-  - gem install bundler
 script: "bundle exec rake --trace"
 
 rvm:
@@ -13,7 +11,7 @@ rvm:
 matrix:
   include:
     - name: "JRuby 9.2"
-      rvm: jruby-9.2.11.1
+      rvm: jruby-9.2.12.0
       jdk: openjdk11
       env: JAVA_OPTS="--add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED"
     - name: Rubinius


### PR DESCRIPTION
**What kind of change is this?**

This PR is a CI change:

  - [x] use latest JRuby - 9.2.12.0
  - [x] drop a `before_install` step - all RVM versions in use have a Bundler
  - [x] JRuby: Try out if the the add-opens settings are still needed or not (still needed)

**Summary of changes**

This is all about keeping the CI configuration small and with only the detail actually needed.

