### PR TITLE
CI, Gemfile: drop Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,7 @@ matrix:
       rvm: jruby-9.2.12.0
       jdk: openjdk11
       env: JAVA_OPTS="--add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED"
-    - name: Rubinius
-      rvm: rbx-4
-      dist: trusty
   allow_failures:
-    - name: Rubinius
     - name: "JRuby 9.2"
   fast_finish: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,3 @@ gem "httpclient", "~> 2.7.1"
 
 gem "simplecov", :require => false
 gem "coveralls", :require => false
-
-platform :rbx do
-  gem 'racc'
-  gem 'rubysl'
-  gem 'rubinius-coverage'
-end


### PR DESCRIPTION
**What kind of change is this?**

CI: Drop Rubinius support.

**Did you add tests for your changes?**

No.

**Summary of changes**

The Rubinius Ruby runtime is no longer rvm-distributed on Travis CI in any easy-to-use way. So, fixing this would be hard.

Keeping Rubinius in the "allow failures" red row in the CI could make it look like we were _going_ to try to fix that. And, like "some parts are broken", when they're not.

