### PR TITLE
Add options for SSL min_version/max_version support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Feature: [#930](https://github.com/savonrb/savon/pull/930) Add options for SSL min_version/max_version support 
 * Fix: [#868](https://github.com/savonrb/savon/pull/868) Remove `xmlns:wsa`'s already added elsewhere; select Content-Type HTTP header based on SOAP version.
 * Add your PR changelog line here
 

--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -229,6 +229,16 @@ module Savon
       @options[:ssl_version] = version
     end
 
+    # Specifies the SSL version to use.
+    def ssl_min_version(version)
+      @options[:ssl_min_version] = version
+    end
+
+    # Specifies the SSL version to use.
+    def ssl_max_version(version)
+      @options[:ssl_max_version] = version
+    end
+
     # Whether and how to to verify the connection.
     def ssl_verify_mode(verify_mode)
       @options[:ssl_verify_mode] = verify_mode

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -26,6 +26,9 @@ module Savon
 
     def configure_ssl
       @http_request.auth.ssl.ssl_version   = @globals[:ssl_version]       if @globals.include? :ssl_version
+      @http_request.auth.ssl.min_version   = @globals[:ssl_min_version]   if @globals.include? :ssl_min_version
+      @http_request.auth.ssl.max_version   = @globals[:ssl_max_version]   if @globals.include? :ssl_max_version
+
       @http_request.auth.ssl.verify_mode   = @globals[:ssl_verify_mode]   if @globals.include? :ssl_verify_mode
       @http_request.auth.ssl.ciphers       = @globals[:ssl_ciphers]       if @globals.include? :ssl_ciphers
 

--- a/savon.gemspec
+++ b/savon.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency "nori",     "~> 2.4"
-  s.add_dependency "httpi",    "~> 2.3"
+  s.add_dependency "httpi",    "~> 2.4.5"
   s.add_dependency "wasabi",   "~> 3.4"
   s.add_dependency "akami",    "~> 1.2"
   s.add_dependency "gyoku",    "~> 1.2"

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -408,6 +408,24 @@ describe "Options" do
     end
   end
 
+  context "global :ssl_min_version" do
+    it "sets the SSL min_version to use" do
+      HTTPI::Auth::SSL.any_instance.expects(:min_version=).with(:TLS1_2).twice
+
+      client = new_client(:endpoint => @server.url, :ssl_min_version => :TLS1_2)
+      client.call(:authenticate)
+    end
+  end
+
+  context "global :ssl_max_version" do
+    it "sets the SSL max_version to use" do
+      HTTPI::Auth::SSL.any_instance.expects(:max_version=).with(:TLS1_2).twice
+
+      client = new_client(:endpoint => @server.url, :ssl_max_version => :TLS1_2)
+      client.call(:authenticate)
+    end
+  end
+
   context "global :ssl_verify_mode" do
     it "sets the verify mode to use" do
       HTTPI::Auth::SSL.any_instance.expects(:verify_mode=).with(:peer).twice

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -88,6 +88,34 @@ describe Savon::WSDLRequest do
       end
     end
 
+    describe "ssl min_version" do
+      it "is set when specified" do
+        globals.ssl_min_version(:TLS1_2)
+        http_request.auth.ssl.expects(:min_version=).with(:TLS1_2)
+
+        new_wsdl_request.build
+      end
+
+      it "is not set otherwise" do
+        http_request.auth.ssl.expects(:min_version=).never
+        new_wsdl_request.build
+      end
+    end
+
+    describe "ssl max_version" do
+      it "is set when specified" do
+        globals.ssl_max_version(:TLS1_2)
+        http_request.auth.ssl.expects(:max_version=).with(:TLS1_2)
+
+        new_wsdl_request.build
+      end
+
+      it "is not set otherwise" do
+        http_request.auth.ssl.expects(:max_version=).never
+        new_wsdl_request.build
+      end
+    end
+
     describe "ssl verify mode" do
       it "is set when specified" do
         globals.ssl_verify_mode(:peer)


### PR DESCRIPTION
**What kind of change is this?**

Feature. This adds support to pass additional options to HTTPI

**Did you add tests for your changes?**

Added unit tests for options_spec and request_spec

**Summary of changes**

OpenSSL's `ssl_version` is deprecated in favor of using min_version and max_version:
https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-ssl_version-3D

HTTPI added support for min/max_version in 2.4.5: https://github.com/savonrb/httpi/releases/tag/v2.4.5

The typical use case is to provide a minimum secured baseline that meets regulatory or security compliance requirements, such as ensuring versions prior to :TLS1_2 are not usable in PCI environments.

**Other information**

I called the options `ssl_min_version` and `ssl_max_version` in Savon while the OptionSSL/HTTPI versions are `min_version` and `max_version`. Happy to drop the `ssl_` here in Savon, but I thought it might be good to specify this option is related to SSL in the option name.
