### PR TITLE
Add log_headers option to globals

### DIFF
--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -79,6 +79,7 @@ module Savon
         :namespaces                  => {},
         :logger                      => Logger.new($stdout),
         :log                         => false,
+        :log_headers                 => true,
         :filters                     => [],
         :pretty_print_xml            => false,
         :raise_errors                => true,
@@ -217,6 +218,11 @@ module Savon
       end
 
       @options[:logger].level = levels[level]
+    end
+
+    # To log headers or not.
+    def log_headers(log_headers)
+      @options[:log_headers] = log_headers
     end
 
     # A list of XML tags to filter from logged SOAP messages.

--- a/lib/savon/request_logger.rb
+++ b/lib/savon/request_logger.rb
@@ -24,17 +24,21 @@ module Savon
       @globals[:log]
     end
 
+    def log_headers?
+      @globals[:log_headers]
+    end
+
     private
 
     def log_request(request)
       logger.info  { "SOAP request: #{request.url}" }
-      logger.info  { headers_to_log(request.headers) }
+      logger.info  { headers_to_log(request.headers) } if log_headers?
       logger.debug { body_to_log(request.body) }
     end
 
     def log_response(response)
       logger.info  { "SOAP response (status #{response.code})" }
-      logger.debug { headers_to_log(response.headers) }
+      logger.debug { headers_to_log(response.headers) } if log_headers?
       logger.debug { body_to_log(response.body) }
     end
 

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -399,6 +399,26 @@ describe "Options" do
     end
   end
 
+  context "global :log_headers" do
+    it "instructs Savon to log SOAP requests and responses headers" do
+      stdout = mock_stdout {
+        client = new_client(:endpoint => @server.url, :log => true)
+        client.call(:authenticate)
+      }
+      soap_header = stdout.string.include? "Content-Type"
+      expect(soap_header).to be true
+    end
+
+    it "stops Savon from logging SOAP requests and responses headers" do
+      stdout = mock_stdout {
+        client = new_client(:endpoint => @server.url, :log => true, :log_headers => false)
+        client.call(:authenticate)
+      }
+      soap_header = stdout.string.include? "Content-Type"
+      expect(soap_header).to be false
+    end
+  end
+
   context "global :ssl_version" do
     it "sets the SSL version to use" do
       HTTPI::Auth::SSL.any_instance.expects(:ssl_version=).with(:TLSv1).twice


### PR DESCRIPTION
**What kind of change is this?**

Feature. This makes logging request and response headers optional

**Did you add tests for your changes?**

Added unit tests for `options_spec`

**Summary of changes**

Motivation: Savon log headers which contain `Authorization` header most of the time and I think it will be better for more security to hide this header from logs or at least add an option to give the developer the freedom to log it or not.

Changes: I did that by adding `log_headers` option to the `GlobalOptions` class and giving it a default value `true`, so the current users won't be affected.

**Other information**
