### PR TITLE
Rake 12.3.3 and rspec 3

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack"
   s.add_development_dependency "puma",  "~> 3.0"
 
-  s.add_development_dependency "rake",  "~> 10.1"
+  s.add_development_dependency "rake",  ">= 12.3.3"
   s.add_development_dependency "rspec", "~> 2.14"
   s.add_development_dependency "mocha", "~> 0.14"
   s.add_development_dependency "json",  "~> 1.7"

--- a/savon.gemspec
+++ b/savon.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "puma",  "~> 3.0"
 
   s.add_development_dependency "rake",  ">= 12.3.3"
-  s.add_development_dependency "rspec", "~> 2.14"
+  s.add_development_dependency "rspec", "~> 3.9"
   s.add_development_dependency "mocha", "~> 0.14"
   s.add_development_dependency "json",  "~> 1.7"
 


### PR DESCRIPTION

**What kind of change is this?**

Address https://github.com/advisories/GHSA-jppv-gw3r-w3q8

This forced an upgrade of rspec to 3.x in order to get tests running -- see https://github.com/rspec/rspec-core/issues/2205  

**Did you add tests for your changes?**

No, dependency upgrade only

**Summary of changes**

"There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |."