### PR TITLE
Development dependency json: newer pin

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake",  ">= 12.3.3"
   s.add_development_dependency "rspec", "~> 3.9"
   s.add_development_dependency "mocha", "~> 0.14"
-  s.add_development_dependency "json",  "~> 1.7"
+  s.add_development_dependency "json",  ">= 2.3.0"
 
   ignores  = File.readlines(".gitignore").grep(/\S+/).map(&:chomp)
   dotfiles = %w[.gitignore .travis.yml .yardopts]


### PR DESCRIPTION
**What kind of change is this?**

There was a security notice about `json` gem versions before 2.3.0.

The change is: use 2.3.0+.

**Did you add tests for your changes?**

No.

**Summary of changes**

Get rid of a security notice about this development dependency.

