### PR TITLE
gemspec: Use Puma >=4.3.8 to avoid security issue

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mail",     "~> 2.5"
 
   s.add_development_dependency "rack"
-  s.add_development_dependency "puma",  "~> 3.0"
+  s.add_development_dependency "puma",  ">= 4.3.8"
 
   s.add_development_dependency "byebug"
   s.add_development_dependency "rake",  ">= 12.3.3"


### PR DESCRIPTION
**What kind of change is this?**

Puma is a development dependency, and this PR updates how we include it, to avoid a warning about a CVE.

**Did you add tests for your changes?**

No.

**Summary of changes**

Mitigates warnings about CVE-2021-29509.

**Other information**

The Puma we pointed to was quite old.

The logs already say: `Using puma 5.3.1` in GH Actions.