### PR TITLE
test: configure RSpec to support --only-failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tmp
 .rspec
 Gemfile.lock
 bin/
+.rspec_status

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
   config.include SpecSupport
   config.mock_with :mocha
   config.order = "random"
+  config.example_status_persistence_file_path = ".rspec_status"
 end
 
 HTTPI.log = false


### PR DESCRIPTION


**What kind of change is this?**

Test configuration fix.

**Did you add tests for your changes?**

No, this is configuration.


**Summary of changes**

In order to use the RSpec feature "rerun only failing tests", this PR adds one setting to the spec helper.

See https://relishapp.com/rspec/rspec-core/docs/command-line/only-failures


