### PR TITLE
build: run on PR, too; cleanup dbl install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Ruby
 
 on:
   - push
+  - pull_request
 
 jobs:
   test:
@@ -18,8 +19,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # bundle installs and caches dependencies
     - name: Run tests
       run: bundle exec rake --trace

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
+
 gemspec
 
 gem "httpclient", "~> 2.7.1"
 
 gem "simplecov", :require => false
+gem "net-smtp" if RUBY_VERSION >= "3.1.0"


### PR DESCRIPTION

**What kind of change is this?**

Build change. And it gets to green 🟢 on ruby-head.

**Did you add tests for your changes?**

None.

**Summary of changes**

In order for incoming changes to be vetted in a useful way, we should run CI jobs also for PRs.

The comment in the YAML configuration explains setup-ruby's `bundler-cache: true` configuration option.

For ruby-head (Ruby v3.1.0), we need to conditionally add a `gem "net-smtp"` in the Gemfile.

