### PR TITLE
build: attempt to use "needs:"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0", head, truffleruby-head]
+        ruby: [2.5, 2.6, 2.7, "3.0", head]
+        include:
+          - ruby: truffleruby-head
+            needs: "test (2.5)" # It takes a long time to run this test, so let's run it after a passing 2.5
     env:
       RAILS_ENV: test
     steps:


### PR DESCRIPTION
In order to conditionally run truffleruby-head, ask its matrix element to wait for 2.5, first.

**What kind of change is this?**

<!-- E.g. a bugfix, feature, refactoring, build change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Summary of changes**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Other information**
