### PR TITLE
test: Configure RSpec w/o monkey-patches

### DIFF
--- a/spec/integration/centra_spec.rb
+++ b/spec/integration/centra_spec.rb
@@ -24,7 +24,7 @@ module LogInterceptor
   end
 end
 
-describe 'Correct translation of attributes to XML' do
+RSpec.describe 'Correct translation of attributes to XML' do
   it "new :@attr syntax: correctly maps a Ruby Hash to XML attributes" do
     LogInterceptor.reset_intercepted_request
 

--- a/spec/integration/email_example_spec.rb
+++ b/spec/integration/email_example_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
  require "spec_helper"
 
-describe "Email example" do
+RSpec.describe "Email example" do
 
   it "passes Strings as they are" do
     client = Savon.client(

--- a/spec/integration/random_quote_spec.rb
+++ b/spec/integration/random_quote_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe 'rpc/encoded binding test' do
+RSpec.describe 'rpc/encoded binding test' do
 
   it 'should should work with WSDLs that have rpc/encoded SOAP binding' do
     client = Savon.client(

--- a/spec/integration/ratp_example_spec.rb
+++ b/spec/integration/ratp_example_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
  require "spec_helper"
 
-describe "RATP example" do
+RSpec.describe "RATP example" do
 
   it "retrieves information about a specific station" do
     client = Savon.client do

--- a/spec/integration/stockquote_example_spec.rb
+++ b/spec/integration/stockquote_example_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
  require "spec_helper"
 
-describe "Stockquote example" do
+RSpec.describe "Stockquote example" do
 
   it "returns the result in a CDATA tag" do
     client = Savon.client(

--- a/spec/integration/temperature_example_spec.rb
+++ b/spec/integration/temperature_example_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
  require "spec_helper"
 
-describe "Temperature example" do
+RSpec.describe "Temperature example" do
 
   it "converts 30 degrees celsius to 86 degrees fahrenheit" do
     client = Savon.client do

--- a/spec/integration/zipcode_example_spec.rb
+++ b/spec/integration/zipcode_example_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
  require "spec_helper"
 
-describe "ZIP code example" do
+RSpec.describe "ZIP code example" do
 
   it "supports threads making requests simultaneously" do
     client = Savon.client(

--- a/spec/savon/builder_spec.rb
+++ b/spec/savon/builder_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Savon::Builder do
+RSpec.describe Savon::Builder do
 
   subject(:builder) { Savon::Builder.new(:authenticate, wsdl, globals, locals) }
 

--- a/spec/savon/client_spec.rb
+++ b/spec/savon/client_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "integration/support/server"
 
-describe Savon::Client do
+RSpec.describe Savon::Client do
 
   before :all do
     @server = IntegrationServer.run

--- a/spec/savon/core_ext/string_spec.rb
+++ b/spec/savon/core_ext/string_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe String do
+RSpec.describe String do
 
   describe "snakecase" do
     it "lowercases one word CamelCase" do

--- a/spec/savon/features/message_tag_spec.rb
+++ b/spec/savon/features/message_tag_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 
-describe Savon do
+RSpec.describe Savon do
 
   it 'knows the message tag for :authentication' do
     message_tag = message_tag_for(:authentication, :authenticate)

--- a/spec/savon/http_error_spec.rb
+++ b/spec/savon/http_error_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Savon::HTTPError do
+RSpec.describe Savon::HTTPError do
   let(:http_error) { Savon::HTTPError.new new_response(:code => 404, :body => "Not Found") }
   let(:http_error_with_empty_body) { Savon::HTTPError.new new_response(:code => 404, :body => "") }
   let(:no_error) { Savon::HTTPError.new new_response }

--- a/spec/savon/log_message_spec.rb
+++ b/spec/savon/log_message_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Savon::LogMessage do
+RSpec.describe Savon::LogMessage do
 
   it "returns the message if it's not XML" do
     message = log_message("hello", [:password], :pretty_print).to_s

--- a/spec/savon/message_spec.rb
+++ b/spec/savon/message_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "integration/support/server"
 
-describe Savon::Message do
+RSpec.describe Savon::Message do
 
   before do
     @server = IntegrationServer.run

--- a/spec/savon/mock_spec.rb
+++ b/spec/savon/mock_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "savon/mock/spec_helper"
 
-describe "Savon's mock interface" do
+RSpec.describe "Savon's mock interface" do
   include Savon::SpecHelper
 
   before :all do

--- a/spec/savon/model_spec.rb
+++ b/spec/savon/model_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "integration/support/server"
 
-describe Savon::Model do
+RSpec.describe Savon::Model do
 
   before :all do
     @server = IntegrationServer.run

--- a/spec/savon/multipart_request_spec.rb
+++ b/spec/savon/multipart_request_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Savon::Builder do
+RSpec.describe Savon::Builder do
 
   let(:globals)     { Savon::GlobalOptions.new({ :endpoint => "http://example.co", :namespace => "http://v1.example.com" }) }
   let(:no_wsdl)     { Wasabi::Document.new }

--- a/spec/savon/observers_spec.rb
+++ b/spec/savon/observers_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "integration/support/server"
 
-describe Savon do
+RSpec.describe Savon do
 
   before :all do
     @server = IntegrationServer.run

--- a/spec/savon/operation_spec.rb
+++ b/spec/savon/operation_spec.rb
@@ -4,7 +4,7 @@ require "integration/support/server"
 require "json"
 require "ostruct"
 
-describe Savon::Operation do
+RSpec.describe Savon::Operation do
 
   let(:globals) { Savon::GlobalOptions.new(:endpoint => @server.url(:repeat), :log => false) }
   let(:wsdl)    { Wasabi::Document.new Fixture.wsdl(:taxcloud) }

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -5,7 +5,7 @@ require "json"
 require "ostruct"
 require "logger"
 
-describe "Options" do
+RSpec.describe "Options" do
 
   before :all do
     @server = IntegrationServer.run

--- a/spec/savon/qualified_message_spec.rb
+++ b/spec/savon/qualified_message_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 
 module Savon
-  describe QualifiedMessage, "#to_hash" do
+  RSpec.describe QualifiedMessage, "#to_hash" do
 
     context "if a key ends with !" do
       let(:used_namespaces) { {} }

--- a/spec/savon/request_logger_spec.rb
+++ b/spec/savon/request_logger_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Savon::RequestLogger do
+RSpec.describe Savon::RequestLogger do
 
   subject            { described_class.new(globals) }
   let(:globals)      { Savon::GlobalOptions.new(:log => true, :pretty_print_xml => true) }

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -2,7 +2,7 @@
 require "spec_helper"
 require "integration/support/server"
 
-describe Savon::WSDLRequest do
+RSpec.describe Savon::WSDLRequest do
 
   let(:globals)      { Savon::GlobalOptions.new }
   let(:http_request) { HTTPI::Request.new }
@@ -298,7 +298,7 @@ describe Savon::WSDLRequest do
 
 end
 
-describe Savon::SOAPRequest do
+RSpec.describe Savon::SOAPRequest do
 
   let(:globals)      { Savon::GlobalOptions.new }
   let(:http_request) { HTTPI::Request.new }

--- a/spec/savon/response_spec.rb
+++ b/spec/savon/response_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Savon::Response do
+RSpec.describe Savon::Response do
 
   let(:globals) { Savon::GlobalOptions.new }
   let(:locals)  { Savon::LocalOptions.new }

--- a/spec/savon/soap_fault_spec.rb
+++ b/spec/savon/soap_fault_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Savon::SOAPFault do
+RSpec.describe Savon::SOAPFault do
   let(:soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault)), nori }
   let(:empty_soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:empty_soap_fault)), nori }
   let(:soap_fault2) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault12)), nori }

--- a/spec/savon/softlayer_spec.rb
+++ b/spec/savon/softlayer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-describe Savon::Builder do
+RSpec.describe Savon::Builder do
 
   subject(:builder) { Savon::Builder.new(:create_object, wsdl, globals, locals) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ RSpec.configure do |config|
   config.mock_with :mocha
   config.order = "random"
   config.example_status_persistence_file_path = ".rspec_status"
+  config.disable_monkey_patching!
 end
 
 HTTPI.log = false


### PR DESCRIPTION
**What kind of change is this?**

A maintenance change to make RSpec usage compliant with the future.


**Did you add tests for your changes?**

No, these were RSpec configuration changes.


**Summary of changes**

- See docs for the RSpec setting [disable_monkey_patching](https://www.rubydoc.info/github/rspec/rspec-core/RSpec%2FCore%2FConfiguration:disable_monkey_patching!) 

> Enables zero monkey patching mode for RSpec. It removes monkey patching of the top-level DSL methods (describe, shared_examples_for, etc) onto main and Module, instead requiring you to prefix these methods with RSpec.. It enables expect-only syntax for rspec-mocks and rspec-expectations. It simply disables monkey patching on whatever pieces of RSpec the user is using.
