### PR TITLE
test: Sort spec support files before requiring them

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ require "rspec"
 require "httpclient"
 
 support_files = File.expand_path("spec/support/**/*.rb")
-Dir[support_files].each { |file| require file }
+Dir[support_files].sort.each { |file| require file }
 
 RSpec.configure do |config|
   config.include SpecSupport


### PR DESCRIPTION

**What kind of change is this?**

Configuration files are loaded by the spec_helper, and this change makes them not file-system dependent for their order. They are now required in the same order on all platforms.


**Did you add tests for your changes?**

No. This was a configuration change for the tests.

<!-- Note that we won't merge your changes if you don't add tests -->

**Summary of changes**

To have a uniform order of require.

