### PR TITLE
gemspec: allow httpi 3.0, too

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency "nori",     "~> 2.4"
-  s.add_dependency "httpi",    "~> 2.4.5"
+  s.add_dependency "httpi",    ">= 2.4.5"
   s.add_dependency "wasabi",   "~> 3.4"
   s.add_dependency "akami",    "~> 1.2"
   s.add_dependency "gyoku",    "~> 1.2"


### PR DESCRIPTION
**What kind of change is this?**

The HTTP client for Savon is httpi. It got a new major release, with https://github.com/savonrb/httpi/releases/tag/v3.0.0 which has a breaking change.

**Did you add tests for your changes?**

No, our current tests should do their job.

**Summary of changes**

Only people who _use_ the features that the Rack Adapter and Socksify gem offer should need them in their dependency graph. Socksify amends classes with some monkey-patches, that some people may not want.


