### PR TITLE
Refactor use of monkey-patched Object#blank?

### DIFF
--- a/lib/savon/qualified_message.rb
+++ b/lib/savon/qualified_message.rb
@@ -44,8 +44,8 @@ module Savon
       Array(values).collect do |value|
         translated_value = translate_tag(value)
         namespace_path   = path + [translated_value]
-        namespace        = @used_namespaces[namespace_path]
-        namespace.blank? ? value : "#{namespace}:#{translated_value}"
+        namespace        = @used_namespaces[namespace_path] || ''
+        namespace.empty? ? value : "#{namespace}:#{translated_value}"
       end
     end
   end


### PR DESCRIPTION
**What kind of change is this?**

<!-- E.g. a bugfix, feature, refactoring, build change, etc… -->
bugfix

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->
No, as at least eight existing tests cover this change.

**Summary of changes**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
The `Object#blank` monkey-patch was [removed](https://github.com/savonrb/savon/blob/master/CHANGELOG.md#0910-2012-06-06) in 0.9.10, but this usage remains. It's problematic, as the implementation can vary depending on whether the definition comes from `nori` or `rails` (among others). For instance, `' '.blank?` is `false` under the implementation from `nori`, but `true` under the implementation from `rails`. I've refactored it to be consistent with `nori`, since that is an actual dependency of `savon`.

**Other information**
