### PR TITLE
ruby 3.1 to test matrix, remove unsupported rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0", head, truffleruby-head]
+        ruby: [2.7, 3.0, 3.1, head, truffleruby-head]
     env:
       RAILS_ENV: test
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true # bundle installs and caches dependencies
-    - name: Run tests
-      run: bundle exec rake --trace
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # bundle installs and caches dependencies
+      - name: Run tests
+        run: bundle exec rake --trace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       RAILS_ENV: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For more examples, you should check out the
 
 ## Ruby version support
 
-* `master` - MRI 2.5, 2.6, 2.7 (same support as Ruby)
+* `master` - MRI 2.7, 3.0, 3.1 (same support as Ruby)
 * 2.12.x - MRI 2.2, 2.3, 2.4, 2.5
 * 2.11.x - MRI 2.0, 2.1, 2.2, and 2.3
 


### PR DESCRIPTION
**What kind of change is this?**

add ruby 3.1 to test matrix

**Did you add tests for your changes?**

n/a

**Summary of changes**

savon ruby support is supposed to follow ruby-lang support status, so I added 3.1 and removed 2.6 from master branch.

**Other information**
