### PR TITLE
[Bugfix] Preventing xmlns:xmlns namespace

### DIFF
--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -121,9 +121,12 @@ module Savon
 
         if @wsdl&.document
           @wsdl.parser.namespaces.each do |identifier, path|
-            next if namespaces.key?("xmlns:#{identifier}")
+            prefixed_identifier = identifier
+            prefixed_identifier = "xmlns:#{prefixed_identifier}" unless prefixed_identifier == 'xmlns'
 
-            namespaces["xmlns:#{identifier}"] = path
+            next if namespaces.key?(prefixed_identifier)
+
+            namespaces[prefixed_identifier] = path
           end
         end
 

--- a/spec/savon/softlayer_spec.rb
+++ b/spec/savon/softlayer_spec.rb
@@ -20,19 +20,23 @@ RSpec.describe Savon::Builder do
         }
       }
 
+      expected_namespaces = {
+        'xmlns'           => "http://schemas.xmlsoap.org/wsdl/",
+        'xmlns:xsd'       => "http://www.w3.org/2001/XMLSchema",
+        'xmlns:xsi'       => "http://www.w3.org/2001/XMLSchema-instance",
+        'xmlns:tns'       => "http://api.service.softlayer.com/soap/v3/",
+        'xmlns:env'       => "http://schemas.xmlsoap.org/soap/envelope/",
+        'xmlns:soap'      => "http://schemas.xmlsoap.org/wsdl/soap/",
+        'xmlns:soap-enc'  => "http://schemas.xmlsoap.org/soap/encoding/",
+        'xmlns:wsdl'      => "http://schemas.xmlsoap.org/wsdl/"
+      }
+
       locals = Savon::LocalOptions.new(message)
       builder = Savon::Builder.new(:create_object, wsdl, globals, locals)
 
       envelope = Nokogiri::XML(builder.to_s).xpath('./env:Envelope').first
 
-      expect(envelope.namespaces['xmlns:xsd']).to eq("http://www.w3.org/2001/XMLSchema")
-      expect(envelope.namespaces['xmlns:xsi']).to eq("http://www.w3.org/2001/XMLSchema-instance")
-      expect(envelope.namespaces['xmlns:tns']).to eq("http://api.service.softlayer.com/soap/v3/")
-      expect(envelope.namespaces['xmlns:env']).to eq("http://schemas.xmlsoap.org/soap/envelope/")
-      expect(envelope.namespaces['xmlns']).to eq("http://schemas.xmlsoap.org/wsdl/")
-      expect(envelope.namespaces['xmlns:soap']).to eq("http://schemas.xmlsoap.org/wsdl/soap/")
-      expect(envelope.namespaces['xmlns:soap-enc']).to eq("http://schemas.xmlsoap.org/soap/encoding/")
-      expect(envelope.namespaces['xmlns:wsdl']).to eq("http://schemas.xmlsoap.org/wsdl/")
+      expect(envelope.namespaces).to match(expected_namespaces)
     end
   end
 end

--- a/spec/savon/softlayer_spec.rb
+++ b/spec/savon/softlayer_spec.rb
@@ -22,7 +22,17 @@ RSpec.describe Savon::Builder do
 
       locals = Savon::LocalOptions.new(message)
       builder = Savon::Builder.new(:create_object, wsdl, globals, locals)
-      expect(builder.to_s).to include('<env:Envelope')
+
+      envelope = Nokogiri::XML(builder.to_s).xpath('./env:Envelope').first
+
+      expect(envelope.namespaces['xmlns:xsd']).to eq("http://www.w3.org/2001/XMLSchema")
+      expect(envelope.namespaces['xmlns:xsi']).to eq("http://www.w3.org/2001/XMLSchema-instance")
+      expect(envelope.namespaces['xmlns:tns']).to eq("http://api.service.softlayer.com/soap/v3/")
+      expect(envelope.namespaces['xmlns:env']).to eq("http://schemas.xmlsoap.org/soap/envelope/")
+      expect(envelope.namespaces['xmlns']).to eq("http://schemas.xmlsoap.org/wsdl/")
+      expect(envelope.namespaces['xmlns:soap']).to eq("http://schemas.xmlsoap.org/wsdl/soap/")
+      expect(envelope.namespaces['xmlns:soap-enc']).to eq("http://schemas.xmlsoap.org/soap/encoding/")
+      expect(envelope.namespaces['xmlns:wsdl']).to eq("http://schemas.xmlsoap.org/wsdl/")
     end
   end
 end


### PR DESCRIPTION
**What kind of change is this?**

Bugfix to prevent "xmlns:xmlns" namespace which is an invalid namespace.

**Did you add tests for your changes?**

I have updated the spec to ensure that the namespaces are the correct ones.

**Summary of changes**

2.13.0 introduced a new bug where it was adding a namespace "xmlns:xmlns" to the envelope and this was resulting in an invalid XML.

**Other information**

When I forked the repo `rake spec:integration` was failing, this change seems to have fixed it as well.
This has fixed an issue I am having in my application as well.

Related issues:
https://github.com/savonrb/savon/issues/976
https://github.com/savonrb/savon/pull/943#issuecomment-1213163418
