### PR TITLE
simplify gemspec s.files

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -34,14 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha", "~> 0.14"
   s.add_development_dependency "json",  ">= 2.3.0"
 
-  ignores  = File.readlines(".gitignore").grep(/\S+/).map(&:chomp)
-  dotfiles = %w[.gitignore .yardopts]
-
-  all_files_without_ignores = Dir["**/*"].reject { |f|
-    File.directory?(f) || ignores.any? { |i| File.fnmatch(i, f) }
-  }
-
-  s.files = (all_files_without_ignores + dotfiles).sort
+  s.files = Dir['CHANGELOG.md', 'LICENSE', 'README.md', 'Rakefile', 'lib/**/*.rb']
 
   s.require_path = "lib"
 end


### PR DESCRIPTION
**What kind of change is this?**

fixes #953 

**Did you add tests for your changes?**

No, I visually built the gem and confirmed the bundled files are as expected / unchanged:

```bash
$ gem build savon.gemspec
$ gem unpack savon-2.13.1.gem
$ tree savon-2.13.1
savon-2.13.1
├── CHANGELOG.md
├── lib
│   ├── savon
│   │   ├── block_interface.rb
│   │   ├── builder.rb
│   │   ├── client.rb
│   │   ├── core_ext
│   │   │   └── string.rb
│   │   ├── header.rb
│   │   ├── http_error.rb
│   │   ├── log_message.rb
│   │   ├── message.rb
│   │   ├── mock
│   │   │   ├── expectation.rb
│   │   │   └── spec_helper.rb
│   │   ├── mock.rb
│   │   ├── model.rb
│   │   ├── operation.rb
│   │   ├── options.rb
│   │   ├── qualified_message.rb
│   │   ├── request_logger.rb
│   │   ├── request.rb
│   │   ├── response.rb
│   │   ├── soap_fault.rb
│   │   └── version.rb
│   └── savon.rb
├── LICENSE
├── Rakefile
└── README.md
```

and: 

```bash
$ tree /usr/local/rvm/gems/ruby-3.1.2/gems/savon-2.13.1/
/usr/local/rvm/gems/ruby-3.1.2/gems/savon-2.13.1/
├── CHANGELOG.md
├── lib
│   ├── savon
│   │   ├── block_interface.rb
│   │   ├── builder.rb
│   │   ├── client.rb
│   │   ├── core_ext
│   │   │   └── string.rb
│   │   ├── header.rb
│   │   ├── http_error.rb
│   │   ├── log_message.rb
│   │   ├── message.rb
│   │   ├── mock
│   │   │   ├── expectation.rb
│   │   │   └── spec_helper.rb
│   │   ├── mock.rb
│   │   ├── model.rb
│   │   ├── operation.rb
│   │   ├── options.rb
│   │   ├── qualified_message.rb
│   │   ├── request_logger.rb
│   │   ├── request.rb
│   │   ├── response.rb
│   │   ├── soap_fault.rb
│   │   └── version.rb
│   └── savon.rb
├── LICENSE
├── Rakefile
└── README.md
```

**Summary of changes**

- simplify the expression for the included gemfiles
- explicitly specify the hardcoded files to include (changelog, license, lib, etc) instead of a list of exclusions
