### PR TITLE
puma 6, rack 3

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |s|
   s.add_dependency "nokogiri", ">= 1.8.1"
   s.add_dependency "mail",     "~> 2.5"
 
-  s.add_development_dependency "rack", " < 3"
-  s.add_development_dependency "puma",  ">= 4.3.8", "< 6"
+  s.add_development_dependency "rack", " < 4"
+  s.add_development_dependency "puma",  ">= 4.3.8", "< 7"
 
   s.add_development_dependency "byebug"
   s.add_development_dependency "rake",  ">= 12.3.3"

--- a/spec/integration/support/server.rb
+++ b/spec/integration/support/server.rb
@@ -28,7 +28,7 @@ class IntegrationServer
     @port = options.fetch(:port, 17172)
     @ssl  = options.fetch(:ssl, false)
 
-    @server = Puma::Server.new(app, events)
+    @server = Puma::Server.new(app, Puma::Events.new)
 
     if ssl?
       add_ssl_listener
@@ -57,10 +57,6 @@ class IntegrationServer
   end
 
   private
-
-  def events
-    Puma::Events.new($stdout, $stderr)
-  end
 
   def add_tcp_listener
     server.add_tcp_listener(host, port)

--- a/spec/savon/mock_spec.rb
+++ b/spec/savon/mock_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Savon's mock interface" do
     expect(response).to be_a_soap_fault
 
     expect(response.http.code).to eq(500)
-    expect(response.http.headers).to eq("X-Result" => "invalid")
+    expect(response.http.headers).to eq("x-result" => "invalid")
     expect(response.http.body).to eq(soap_fault)
   end
 

--- a/spec/savon/observers_spec.rb
+++ b/spec/savon/observers_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Savon do
 
         def notify(*)
           # return a response to mock the request
-          HTTPI::Response.new(201, { "X-Result" => "valid" }, "valid!")
+          HTTPI::Response.new(201, { "x-result" => "valid" }, "valid!")
         end
 
       }.new
@@ -61,7 +61,7 @@ RSpec.describe Savon do
       response = new_client.call(:authenticate)
 
       expect(response.http.code).to eq(201)
-      expect(response.http.headers).to eq("X-Result" => "valid")
+      expect(response.http.headers).to eq("x-result" => "valid")
       expect(response.http.body).to eq("valid!")
     end
 

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe "Options" do
         client = new_client(:endpoint => @server.url, :log => true)
         client.call(:authenticate)
       }
-      soap_header = stdout.string.include? "Content-Type"
+      soap_header = stdout.string.include? "content-type"
       expect(soap_header).to be true
     end
 


### PR DESCRIPTION
**What kind of change is this?**

support puma 6.x and rack 3.x in development
Fixes #979, fixes #980

**Did you add tests for your changes?**

changes made to ensure tests are passing

**Summary of changes**

- api change in constructor for Puma::Events https://github.com/puma/puma/blob/master/6.0-Upgrade.md#upgrade
- rack response headers must be lowercase https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#response-headers-must-be-lower-case

There are now some noisy warnings emitted by httpi dependency, but this is tracked by https://github.com/savonrb/httpi/issues/236 and appears to be harmless for now