### PR TITLE
rename Savon::Response#hash

### DIFF
--- a/lib/savon/response.rb
+++ b/lib/savon/response.rb
@@ -55,7 +55,7 @@ module Savon
     end
 
     def response_hash
-      @hash ||= nori.parse(xml)
+      @response_hash ||= nori.parse(xml)
     end
 
     def xml

--- a/lib/savon/response.rb
+++ b/lib/savon/response.rb
@@ -54,8 +54,8 @@ module Savon
       result.kind_of?(Array) ? result.compact : [result].compact
     end
 
-    def response_hash
-      @response_hash ||= nori.parse(xml)
+    def full_hash
+      @full_hash ||= nori.parse(xml)
     end
 
     def xml
@@ -79,7 +79,7 @@ module Savon
     end
 
     def find(*path)
-      envelope = nori.find(response_hash, 'Envelope')
+      envelope = nori.find(full_hash, 'Envelope')
       raise_invalid_response_error! unless envelope.is_a?(Hash)
 
       nori.find(envelope, *path)

--- a/lib/savon/response.rb
+++ b/lib/savon/response.rb
@@ -54,7 +54,7 @@ module Savon
       result.kind_of?(Array) ? result.compact : [result].compact
     end
 
-    def hash
+    def response_hash
       @hash ||= nori.parse(xml)
     end
 
@@ -79,7 +79,7 @@ module Savon
     end
 
     def find(*path)
-      envelope = nori.find(hash, 'Envelope')
+      envelope = nori.find(response_hash, 'Envelope')
       raise_invalid_response_error! unless envelope.is_a?(Hash)
 
       nori.find(envelope, *path)

--- a/spec/savon/mock_spec.rb
+++ b/spec/savon/mock_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Savon's mock interface" do
 
   it "accepts a Hash to specify the response code, headers and body" do
     soap_fault = Fixture.response(:soap_fault)
-    response = { :code => 500, :headers => { "X-Result" => "invalid" }, :body => soap_fault }
+    response = { :code => 500, :headers => { "x-result" => "invalid" }, :body => soap_fault }
 
     savon.expects(:authenticate).returns(response)
     response = new_client(:raise_errors => false).call(:authenticate)

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -850,7 +850,7 @@ RSpec.describe "Options" do
 
       response = client.call(:authenticate, :xml => Fixture.response(:authentication))
 
-      expect(response.hash["soap:envelope"]["soap:body"]).to include("ns2:authenticate_response")
+      expect(response.response_hash["soap:envelope"]["soap:body"]).to include("ns2:authenticate_response")
     end
   end
 
@@ -880,7 +880,7 @@ RSpec.describe "Options" do
       client = new_client(:endpoint => @server.url(:repeat), :convert_response_tags_to => lambda { |tag| tag.snakecase.upcase })
       response = client.call(:authenticate, :xml => Fixture.response(:authentication))
 
-      expect(response.hash["ENVELOPE"]["BODY"]).to include("AUTHENTICATE_RESPONSE")
+      expect(response.response_hash["ENVELOPE"]["BODY"]).to include("AUTHENTICATE_RESPONSE")
     end
 
     it "accepts a block in the block-based interface" do
@@ -895,7 +895,7 @@ RSpec.describe "Options" do
         locals.xml Fixture.response(:authentication)
       end
 
-      expect(response.hash["ENVELOPE"]["BODY"]).to include("AUTHENTICATE_RESPONSE")
+      expect(response.response_hash["ENVELOPE"]["BODY"]).to include("AUTHENTICATE_RESPONSE")
     end
   end
 

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe "Options" do
         client = new_client(:endpoint => @server.url, :log => true)
         client.call(:authenticate)
       }
-      soap_header = stdout.string.include? "content-type"
+      soap_header = stdout.string.downcase.include? "content-type"
       expect(soap_header).to be true
     end
 
@@ -850,7 +850,7 @@ RSpec.describe "Options" do
 
       response = client.call(:authenticate, :xml => Fixture.response(:authentication))
 
-      expect(response.response_hash["soap:envelope"]["soap:body"]).to include("ns2:authenticate_response")
+      expect(response.full_hash["soap:envelope"]["soap:body"]).to include("ns2:authenticate_response")
     end
   end
 
@@ -880,7 +880,7 @@ RSpec.describe "Options" do
       client = new_client(:endpoint => @server.url(:repeat), :convert_response_tags_to => lambda { |tag| tag.snakecase.upcase })
       response = client.call(:authenticate, :xml => Fixture.response(:authentication))
 
-      expect(response.response_hash["ENVELOPE"]["BODY"]).to include("AUTHENTICATE_RESPONSE")
+      expect(response.full_hash["ENVELOPE"]["BODY"]).to include("AUTHENTICATE_RESPONSE")
     end
 
     it "accepts a block in the block-based interface" do
@@ -895,7 +895,7 @@ RSpec.describe "Options" do
         locals.xml Fixture.response(:authentication)
       end
 
-      expect(response.response_hash["ENVELOPE"]["BODY"]).to include("AUTHENTICATE_RESPONSE")
+      expect(response.full_hash["ENVELOPE"]["BODY"]).to include("AUTHENTICATE_RESPONSE")
     end
   end
 

--- a/spec/savon/response_spec.rb
+++ b/spec/savon/response_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Savon::Response do
   describe "#hash" do
     it "should return the complete SOAP response XML as a Hash" do
       response = soap_response :body => Fixture.response(:header)
-      expect(response.hash[:envelope][:header][:session_number]).to eq("ABCD1234")
+      expect(response.response_hash[:envelope][:header][:session_number]).to eq("ABCD1234")
     end
   end
 

--- a/spec/savon/response_spec.rb
+++ b/spec/savon/response_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Savon::Response do
     describe "##{method}" do
       it "should return the SOAP response body as a Hash" do
         expect(soap_response.send(method)[:authenticate_response][:return]).to eq(
-          Fixture.response_hash(:authentication)[:authenticate_response][:return]
+          Fixture.full_hash(:authentication)[:authenticate_response][:return]
         )
       end
 
@@ -180,7 +180,7 @@ RSpec.describe Savon::Response do
     context "when the given path exists" do
       it "should return an Array containing the path value" do
         expect(soap_response.to_array(:authenticate_response, :return)).to eq(
-          [Fixture.response_hash(:authentication)[:authenticate_response][:return]]
+          [Fixture.full_hash(:authentication)[:authenticate_response][:return]]
         )
       end
 
@@ -206,7 +206,7 @@ RSpec.describe Savon::Response do
   describe "#hash" do
     it "should return the complete SOAP response XML as a Hash" do
       response = soap_response :body => Fixture.response(:header)
-      expect(response.response_hash[:envelope][:header][:session_number]).to eq("ABCD1234")
+      expect(response.full_hash[:envelope][:header][:session_number]).to eq("ABCD1234")
     end
   end
 

--- a/spec/support/fixture.rb
+++ b/spec/support/fixture.rb
@@ -9,9 +9,9 @@ class Fixture
       fixtures(type)[fixture] ||= read_file type, fixture
     end
 
-    def response_hash(fixture)
-      @response_hash ||= {}
-      @response_hash[fixture] ||= nori.parse(response(fixture))[:envelope][:body]
+    def full_hash(fixture)
+      @full_hash ||= {}
+      @full_hash[fixture] ||= nori.parse(response(fixture))[:envelope][:body]
     end
 
     TYPES.each do |type, ext|


### PR DESCRIPTION
**What kind of change is this?**

make sure we don't unintentionally clobber [Object#hash](https://ruby-doc.org/core-3.1.2/Object.html#method-i-hash) in `Savon::Response` class

**Did you add tests for your changes?**

existing tests updated to reflect the new name

**Summary of changes**

- renamed to `Savon::Response#response_hash`
  - bad name because `to_hash` was already taken, and means something totally different (its an alias for `Savon::Response#body`). i could've done `to_h` but that feels confusing 
  - suggestions welcome. `full_hash`?
- See #950 for motivation
- this would be a breaking change so it would need a commensurate version bump (can we bundle any other breaking changes to minimize thrash?)