### PR TITLE
gemspec: Require wasabi version that supports Ruby 3

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "nori",     "~> 2.4"
   s.add_dependency "httpi",    ">= 2.4.5"
-  s.add_dependency "wasabi",   ">= 3.4"
+  s.add_dependency "wasabi",   ">= 3.7"
   s.add_dependency "akami",    "~> 1.2"
   s.add_dependency "gyoku",    "~> 1.2"
   s.add_dependency "builder",  ">= 2.1.2"


### PR DESCRIPTION
**What kind of change is this?**

Bugfix

**Did you add tests for your changes?**

No. There does not appear to be a way to test against different combinations of gems.

**Summary of changes**

Wasabi < 3.6 uses `URI.unescape` which does not exist in Ruby 3. Wasabi does not test against Ruby 3 until v3.7, which is why the minimum is set to 3.7.

https://github.com/savonrb/savon/issues/996

**Other information**

Recommend to patch 2.13 and 2.14 because they both support Ruby 3 according to the CI config.
