### PR TITLE
CI: Avoid 3.0 becoming "3" in YAML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.0, 3.1, 3.2, 3.3, head, truffleruby-head]
+        ruby: ['3.0', 3.1, 3.2, 3.3, head, truffleruby-head]
     env:
       RAILS_ENV: test
     steps:


### PR DESCRIPTION
**What kind of change is this?**

This is a change to the CI build configuration.

**Did you add tests for your changes?**

None, the change can be seen in how the names of the matrix elements are displayed.

**Summary of changes**

When stringifying 3.0, the CI's YAML engine would create the string "3" rather than "3.0". Turning this specific value into a String avoids this display difference.


This is a very small change, but which avoids a Float-to-String loss of characters.

An example (not from this project) of what it can look like before this change, in this picture:

<img width="376" alt="bild" src="https://user-images.githubusercontent.com/211/119782378-6ad6cd00-becc-11eb-9e13-9a425adaa054.png">

Read more details, if you like: https://github.com/actions/runner/issues/849