### PR TITLE
Remove Content-Length computing

### DIFF
--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -109,10 +109,6 @@ module Savon
         request.headers["MIME-Version"] = "1.0"
       end
 
-      # TODO: could HTTPI do this automatically in case the header
-      #       was not specified manually? [dh, 2013-01-04]
-      request.headers["Content-Length"] = request.body.bytesize.to_s
-
       request
     end
 


### PR DESCRIPTION
**What kind of change is this?**

Remove an old TODO.

**Did you add tests for your changes?**

TODO.

**Summary of changes**

Modern versions of HTTPI already do this and some servers do not like having two headers `Content-Length` (even with same value).
