### PR TITLE
Pass the provided Savon/custom logger to Faraday

### DIFF
--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -77,7 +77,7 @@ module Savon
     end
 
     def configure_logging
-      connection.response(:logger, nil, headers: @globals[:log_headers], level: @globals[:logger].level) if @globals[:log]
+      connection.response(:logger, @globals[:logger], headers: @globals[:log_headers]) if @globals[:log]
     end
 
     protected

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe "Options" do
     end
 
     it "silences Faraday as well" do
-      Faraday::Connection.any_instance.expects(:response).with(:logger, nil, {:headers => true, :level => 0}).never
+      Faraday::Connection.any_instance.expects(:response).never
 
       new_client(:log => false)
     end
@@ -346,7 +346,7 @@ RSpec.describe "Options" do
     end
 
     it "turns Faraday logging back on as well" do
-      Faraday::Connection.any_instance.expects(:response).with(:logger, nil, {:headers => true, :level => 0}).at_least_once
+      Faraday::Connection.any_instance.expects(:response).with(:logger, kind_of(Logger), {:headers => true}).at_least_once
       new_client(:log => true)
     end
   end
@@ -367,10 +367,10 @@ RSpec.describe "Options" do
     end
 
     it "sets the logger of faraday connection as well" do
-      Faraday::Connection.any_instance.expects(:response).with(:logger, nil, {:headers => true, :level => 0}).at_least_once
+      custom_logger = Logger.new($stdout)
+      custom_logger.level = :fatal
+      Faraday::Connection.any_instance.expects(:response).with(:logger, custom_logger, {:headers => true}).at_least_once
       mock_stdout {
-        custom_logger = Logger.new($stdout)
-
         client = new_client(:endpoint => @server.url, :logger => custom_logger, :log => true)
         client.call(:authenticate)
       }


### PR DESCRIPTION
**What kind of change is this?**

A bugfix for savon-3.0.0.rc1

**Did you add tests for your changes?**

I modified already present tests.

**Summary of changes**

If the Savon logger isn't passed to Faraday, it builds a new logger to $stdout and logs to it. This results in stdout logging whenever `log: true` is set as a savon option, instead of logging to a file or so.

Passing the Savon/custom logger to Faraday avoids the creation of a second logger object by Faraday and allows to capture all logs to a user provided Logger object.

**Other information**

This patch also removes the `level` option, which is [no recognized Faraday option](https://lostisland.github.io/faraday/#/middleware/included/logging?id=change-log-level). There is the option `log_level` only, which determines which log level which the messages are flagged by Faraday. In contrast the `log_level` option of Savon determines the minimum level of logs, which are captured by the logger.

