### PR TITLE
Add ostruct support to fix CI

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "puma",  ">= 4.3.8", "< 7"
   s.add_development_dependency "httpclient"
   s.add_development_dependency "mutex_m"
+  s.add_development_dependency 'ostruct', '~> 0.6'
 
   s.add_development_dependency "byebug"
   s.add_development_dependency "rake",  ">= 12.3.3"


### PR DESCRIPTION
**What kind of change is this?**

bugfix

**Did you add tests for your changes?**

N/A

**Summary of changes**

Require 'ostruct' as a dependency, to fix CI on future ruby versions.

Fix #1022 

**Other information**
