### PR TITLE
Drop ruby 3.0 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', 3.1, 3.2, 3.3, 3.4, head, truffleruby-head]
+        ruby: [3.1, 3.2, 3.3, 3.4, head, truffleruby-head]
     env:
       RAILS_ENV: test
     steps:


### PR DESCRIPTION

**What kind of change is this?**

build change

**Did you add tests for your changes?**

N/A

**Summary of changes**

3.0 is EOL as per review comment
3.1 is EOL on the 31st; but leaving it for the moment


**Other information**
