### PR TITLE
Add option to provide connection middlewares.

### DIFF
--- a/lib/savon/options.rb
+++ b/lib/savon/options.rb
@@ -92,6 +92,7 @@ module Savon
         :convert_attributes_to       => lambda { |k,v| [k,v] },
         :multipart                   => false,
         :adapter                     => nil,
+        :middlewares                 => [],
         :use_wsa_headers             => false,
         :no_message_tag              => false,
         :follow_redirects            => false,
@@ -383,6 +384,25 @@ module Savon
     # Instruct requests to follow HTTP redirects.
     def follow_redirects(follow_redirects)
       @options[:follow_redirects] = follow_redirects
+    end
+
+    # Provide middlewares for Faraday connections.
+    # The argument is an array, with each element being another array
+    # that contains the middleware class and its arguments, in the same way
+    # as a normal call to Faraday::RackBuilder#use
+    #
+    # See https://lostisland.github.io/faraday/#/middleware/index?id=using-middleware
+    # For example:
+    #
+    # client = Savon.client(
+    #   middlewares: [
+    #     [Faraday::Request::UrlEncoded],
+    #     [Faraday::Response::Logger, { bodies: true }],
+    #     [Faraday::Adapter::NetHttp]
+    #   ]
+    # )
+    def middlewares(middlewares)
+      @options[:middlewares] = middlewares
     end
   end
 

--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -80,6 +80,12 @@ module Savon
       connection.response(:logger, @globals[:logger], headers: @globals[:log_headers]) if @globals[:log]
     end
 
+    def configure_middlewares
+      @globals[:middlewares].each do |middleware_args|
+        connection.use(*middleware_args)
+      end
+    end
+
     protected
     attr_reader :connection
   end
@@ -92,6 +98,7 @@ module Savon
       configure_ssl
       configure_auth
       configure_adapter
+      configure_middlewares
       configure_logging
       configure_headers
       connection
@@ -119,6 +126,7 @@ module Savon
       configure_headers(options[:soap_action], options[:headers])
       configure_cookies(options[:cookies])
       configure_adapter
+      configure_middlewares
       configure_logging
       configure_redirect_handling
       yield(connection) if block_given?

--- a/spec/savon/options_spec.rb
+++ b/spec/savon/options_spec.rb
@@ -947,6 +947,19 @@ RSpec.describe "Options" do
     end
   end
 
+  context "global :middlewares" do
+    let(:middlewares) { [[1],[2],[3]] }
+
+    it "adds middlewares to the connection" do
+      middleware_setup = sequence('middleware_setup')
+      Faraday::Connection.any_instance.expects(:use).with(1).in_sequence(middleware_setup)
+      Faraday::Connection.any_instance.expects(:use).with(2).in_sequence(middleware_setup)
+      Faraday::Connection.any_instance.expects(:use).with(3).in_sequence(middleware_setup)
+
+      client = new_client(:endpoint => @server.url, :middlewares => middlewares)
+    end
+  end
+
   context "global and request :soap_header" do
     it "merges the headers if both were provided as Hashes" do
       global_soap_header = {

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -178,8 +178,25 @@ RSpec.describe Savon::WSDLRequest do
         new_wsdl_request.build
       end
     end
-  end
 
+    describe "middlewares" do
+      it "are set when specified" do
+        globals.middlewares([[1], [2, "two", { two: 2 }], [3]])
+
+        middleware_setup = sequence('middleware_setup')
+        http_connection.expects(:use).with(1).in_sequence(middleware_setup)
+        http_connection.expects(:use).with(2, "two", two: 2).in_sequence(middleware_setup)
+        http_connection.expects(:use).with(3).in_sequence(middleware_setup)
+
+        new_wsdl_request.build
+      end
+
+      it "are not set otherwise" do
+        http_connection.expects(:use).never
+        new_wsdl_request.build
+      end
+    end
+  end
 end
 
 RSpec.describe Savon::SOAPRequest do
@@ -376,6 +393,23 @@ RSpec.describe Savon::SOAPRequest do
         new_soap_request.build
       end
     end
-  end
 
+    describe "middlewares" do
+      it "are set when specified" do
+        globals.middlewares([[1], [2, "two", { two: 2 }], [3]])
+
+        middleware_setup = sequence('middleware_setup')
+        http_connection.expects(:use).with(1).in_sequence(middleware_setup)
+        http_connection.expects(:use).with(2, "two", two: 2).in_sequence(middleware_setup)
+        http_connection.expects(:use).with(3).in_sequence(middleware_setup)
+
+        new_soap_request.build
+      end
+
+      it "are not set otherwise" do
+        http_connection.expects(:use).never
+        new_soap_request.build
+      end
+    end
+  end
 end


### PR DESCRIPTION
**What kind of change is this?**

A small feature to allow providing Faraday middlewares as an option.

**Did you add tests for your changes?**

Yes.

**Summary of changes**

Faraday allows [adding middlewares](https://lostisland.github.io/faraday/#/middleware/index) to add additional processing like caching, metrics logging, encoding, etc.

There is currently no option in Savon for this, so this pull requests adds it. Specifically, `Savon::Request` handles this new option by adding the middleware to the connection, with its public `#use` method.