### PR TITLE
Don't block minor updates to faraday

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency "nori",     "~> 2.4"
-  s.add_dependency "faraday",  "~> 2.11.0"
+  s.add_dependency "faraday",  "~> 2.11"
   s.add_dependency "faraday-gzip",  "~> 2.0"
   s.add_dependency "faraday-follow_redirects",  "~> 0.3"
   s.add_dependency "wasabi", " > 5"


### PR DESCRIPTION
**What kind of change is this?**

Small bugfix.

**Did you add tests for your changes?**

Not necessary. The CI tests will pick newer faraday versions and we'll see if it works.

**Summary of changes**

The faraday version constraint was changed in #1020, since SSL ciphers are available from faraday-2.11.0 upwards. They are still supported in 2.12 and newer, so that there's no reason to force 2.11.x only.

**Other information**
