### PR TITLE
Add gzip middleware when Accept-Encoding includes gzip

### DIFF
--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -80,6 +80,12 @@ module Savon
       connection.response(:logger, @globals[:logger], headers: @globals[:log_headers]) if @globals[:log]
     end
 
+    def configure_gzip
+      if connection.headers['Accept-Encoding'] && connection.headers['Accept-Encoding'].include?('gzip')
+        connection.request :gzip
+      end
+    end
+
     protected
     attr_reader :connection
   end
@@ -94,6 +100,7 @@ module Savon
       configure_adapter
       configure_logging
       configure_headers
+      configure_gzip
       connection
     end
 
@@ -121,6 +128,7 @@ module Savon
       configure_adapter
       configure_logging
       configure_redirect_handling
+      configure_gzip
       yield(connection) if block_given?
       connection
     end

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -274,6 +274,28 @@ RSpec.describe Savon::SOAPRequest do
       end
     end
 
+    describe "gzip" do
+      it "is set when Accept-Encoding with gzip is specified" do
+        globals.headers("Accept-Encoding" => "gzip,deflate")
+        http_connection.expects(:request).with(:gzip)
+
+        new_soap_request.build
+      end
+
+      it "is not set when Acccept-Encoding does not include gzip" do
+        globals.headers("Accept-Encoding" => "deflate")
+        http_connection.expects(:request).with(:gzip).never
+
+        new_soap_request.build
+      end
+
+      it "is not set otherwise" do
+        http_connection.expects(:request).with(:gzip).never
+
+        new_soap_request.build
+      end
+    end
+
     describe "SOAPAction header" do
       it "is set and wrapped in parenthesis" do
         configured_http_request = new_soap_request.build(:soap_action => "findUser")


### PR DESCRIPTION
**What kind of change is this?**

Feature

**Did you add tests for your changes?**

Tests are added

**Summary of changes**

After the update to use faraday instead of httpi the response body was no longer decoded if it was encoded using gzip.

So this change adds the gzip middleware to requests if Accept-Encoding contains gzip

**Other information**
