### PR TITLE
Fix undefined variable in NTLM authentication

### DIFF
--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -94,7 +94,7 @@ module Savon
       ntlm_auth = handle_ntlm(connection) if @globals.include?(:ntlm)
       @logger.log_response(connection.post(@globals[:endpoint]) { |request|
         request.body = @locals[:body]
-        request.headers['Authorization'] = "NTLM #{auth.encode64}" if ntlm_auth
+        request.headers['Authorization'] = "NTLM #{ntlm_auth.encode64}" if ntlm_auth
         @logger.log_request(request)
       })
     end

--- a/spec/savon/operation_spec.rb
+++ b/spec/savon/operation_spec.rb
@@ -273,4 +273,24 @@ RSpec.describe Savon::Operation do
     hash = JSON.parse(response.http.body)
     OpenStruct.new(hash)
   end
+
+  describe "NTLM authentication" do
+    it "sets the Authorization header after handshake" do
+      require "rubyntlm"
+
+      globals_with_ntlm = Savon::GlobalOptions.new(
+        endpoint: @server.url(:repeat),
+        namespace: "http://v1.example.com",
+        ntlm: ["username", "password", "domain"],
+        log: false,
+      )
+
+      operation = new_operation(:authenticate, no_wsdl, globals_with_ntlm)
+
+      mock_ntlm_response = stub(encode64: "mock_ntlm_token")
+      operation.stubs(:handle_ntlm).returns(mock_ntlm_response)
+
+      expect { operation.call }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Fixes typo in `call_with_logging` where `auth` was used instead of `ntlm_auth`.

Adds test coverage for the NTLM auth header flow.

### Did you add tests for your changes?

Yes 🙂