### PR TITLE
Update faraday-gzip dependency for ruby 4.0.0 compatibility

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "nori",     "~> 2.4"
   s.add_dependency "faraday",  "~> 2.11"
-  s.add_dependency "faraday-gzip",  "~> 2.0"
+  s.add_dependency "faraday-gzip",  "~> 3.0"
   s.add_dependency "faraday-follow_redirects",  "~> 0.3"
   s.add_dependency "wasabi", " > 5"
   s.add_dependency "akami",    "~> 1.2"


### PR DESCRIPTION
**What kind of change is this?**

Update gem dependency for ruby 4.0.0 compatibility

**Did you add tests for your changes?**

No new tests needed, existing test suite passes locally on Ruby 4.0.0. However, there looks to be an issue on CI run (head).

**Summary of changes**

faraday-gzip gem dependency updated from `~> 2.0` to `~> 3.0` for ruby 4.0.0 compatibility

**Other information**
