### PR TITLE
Allow faraday-gzip 3.x as well

### DIFF
--- a/savon.gemspec
+++ b/savon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "nori",     "~> 2.4"
   s.add_dependency "faraday",  "~> 2.11"
-  s.add_dependency "faraday-gzip",  "~> 2.0"
+  s.add_dependency "faraday-gzip",  "> 2.0"
   s.add_dependency "faraday-follow_redirects",  "~> 0.3"
   s.add_dependency "wasabi", " > 5"
   s.add_dependency "akami",    "~> 1.2"


### PR DESCRIPTION
**What kind of change is this?**

Version restriction loosening for faraday-gzip: allow 3.x as well.

**Did you add tests for your changes?**

No, not necessary I think. All tests still pass.

**Summary of changes**

Locking faraday.gzip to 2.x prevents upgrading to Ruby 4, as Ruby 4 support was added in faraday-gzip 3.1.

**Other information**

Fixes #1036.