### PR TITLE
Fix `WSDLRequest` ignoring `follow_redirects` option

### DIFF
--- a/lib/savon/request.rb
+++ b/lib/savon/request.rb
@@ -85,7 +85,7 @@ module Savon
         connection.use(*middleware_args)
       end
     end
-    
+
     def configure_gzip
       if connection.headers['Accept-Encoding'] && connection.headers['Accept-Encoding'].include?('gzip')
         connection.request :gzip
@@ -106,6 +106,7 @@ module Savon
       configure_adapter
       configure_middlewares
       configure_logging
+      configure_redirect_handling
       configure_headers
       configure_gzip
       connection

--- a/spec/savon/request_spec.rb
+++ b/spec/savon/request_spec.rb
@@ -196,6 +196,20 @@ RSpec.describe Savon::WSDLRequest do
         new_wsdl_request.build
       end
     end
+
+    describe "follow redirects" do
+      it "is set when specified" do
+        globals.follow_redirects(true)
+        http_connection.expects(:response).with(:follow_redirects)
+
+        new_wsdl_request.build
+      end
+
+      it "is not set otherwise" do
+        http_connection.expects(:response).with(:follow_redirects).never
+        new_wsdl_request.build
+      end
+    end
   end
 end
 


### PR DESCRIPTION
**What kind of change is this?**

Small bugfix

**Did you add tests for your changes?**

Yes

**Summary of changes**

725855d accidentally dropped the `configure_redirect_handling` call from `WSDLRequest#build` while keeping it in `SOAPRequest#build`. The issue was reported in #1033.
