### PR TITLE
Remove Content-Length computing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Savon changelog
 
+## UPCOMING
+
+* Fix: [#1008](https://github.com/savonrb/savon/pull/1008) - Removed Content-Length computing from Faraday and HTTPI transports.
+
 ## 2.17.0 (2026-05-19)
 
 **Add opt-in Faraday transport**

--- a/spec/integration/support/application.rb
+++ b/spec/integration/support/application.rb
@@ -41,11 +41,14 @@ class IntegrationServer
 
     map "/inspect_request" do
       run lambda { |env|
+        request_body = env["rack.input"].read
         body = {
           soap_action: env["HTTP_SOAPACTION"],
           cookie: env["HTTP_COOKIE"],
           x_token: env["HTTP_X_TOKEN"],
-          content_type: env["CONTENT_TYPE"]
+          content_type: env["CONTENT_TYPE"],
+          content_length: env["CONTENT_LENGTH"],
+          body_bytesize: request_body.bytesize.to_s
         }
 
         IntegrationServer.respond_with body: JSON.dump(body)

--- a/spec/savon/features/faraday_spec.rb
+++ b/spec/savon/features/faraday_spec.rb
@@ -82,4 +82,16 @@ RSpec.describe "Savon client with transport: :faraday" do
     response = client.call(:authenticate, cookies: [HTTPI::Cookie.new("session=abc")])
     expect(inspect_request(response).cookie).to include("session=abc")
   end
+
+  it "sends the exact Content-Length on the wire (via the Faraday adapter)" do
+    client = Savon.client(
+      endpoint: @server.url(:inspect_request),
+      namespace: "http://v1.example.com",
+      transport: :faraday,
+      log: false
+    )
+    data = inspect_request(client.call(:authenticate))
+    expect(data.content_length).to match(/\A\d+\z/), "expected a single integer - a comma would mean the header was sent twice"
+    expect(data.content_length).to eq(data.body_bytesize)
+  end
 end

--- a/spec/savon/operation_spec.rb
+++ b/spec/savon/operation_spec.rb
@@ -104,9 +104,14 @@ RSpec.describe Savon::Operation do
       end
     end
 
-    it "sets Content-Length to the byte size of the body" do
-      request = operation.request
-      expect(request.headers["Content-Length"]).to eq(request.body.bytesize.to_s)
+    context "when verifying Content-Length via the HTTPI adapter" do
+      let(:globals) { Savon::GlobalOptions.new(endpoint: @server.url(:inspect_request), log: false) }
+
+      it "sends the exact Content-Length on the wire (via the HTTPI adapter)" do
+        data = inspect_request(operation.call)
+        expect(data.content_length).to match(/\A\d+\z/), "expected a single integer not multiple values"
+        expect(data.content_length).to eq(data.body_bytesize)
+      end
     end
 
     it "converts cookies to a Cookie: header on the request" do

--- a/spec/savon/transport/faraday_spec.rb
+++ b/spec/savon/transport/faraday_spec.rb
@@ -121,17 +121,6 @@ RSpec.describe Savon::Transport::Faraday do
       expect(captured.request_headers["Cookie"]).to eq("session=abc;user=dan")
     end
 
-    it "computes Content-Length from the body byte size" do
-      body_str = "hello"
-      captured = nil
-      stubs.post("/soap") do |env|
-        captured = env
-        [200, {}, "ok"]
-      end
-      transport.post(url, {}, body_str, locals)
-      expect(captured.request_headers["Content-Length"]).to eq(body_str.bytesize.to_s)
-    end
-
     it "skips LogMessage construction when the logger level would suppress the output" do
       globals_logging = Savon::GlobalOptions.new(log: true)
       globals_logging[:logger].level = Logger::FATAL

--- a/spec/savon/transport/httpi_spec.rb
+++ b/spec/savon/transport/httpi_spec.rb
@@ -62,11 +62,6 @@ RSpec.describe Savon::Transport::HTTPI do
       locals_with_cookies = Savon::LocalOptions.new(cookies: cookies)
       expect(transport.to_httpi_request(url, {}, body, locals_with_cookies).headers["Cookie"]).to eq("session=abc;user=dan")
     end
-
-    it "computes Content-Length from the body byte size" do
-      body_str = "hello"
-      expect(transport.to_httpi_request(url, {}, body_str, locals).headers["Content-Length"]).to eq(body_str.bytesize.to_s)
-    end
   end
 
   describe "#post" do


### PR DESCRIPTION
Backported #1008 to v2.x and added tests.
Thanks @Ezveus