### PR TITLE
Disable bundler cache in gem push workflow

### DIFF
--- a/.github/workflows/gem_push.yml
+++ b/.github/workflows/gem_push.yml
@@ -17,4 +17,6 @@ jobs:
         with:
           ruby-version: "3"
           bundler-cache: false
+      - name: Install dependencies
+        run: bundle install
       - uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0

--- a/.github/workflows/gem_push.yml
+++ b/.github/workflows/gem_push.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: "3"
-          bundler-cache: true
+          bundler-cache: false
       - uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0


### PR DESCRIPTION
**What kind of change is this?**

a bug fix

**Did you add tests for your changes?**

It's a CI job change, can't really be tested but I'm certain it's safe.

**Summary of changes**

To prevent any risk of a cache poisoning attack being able to effect the release job. I noticed this via the zizmor cache poisoning rule, which called it out as a possible vector for abuse: https://docs.zizmor.sh/audits/#cache-poisoning

The main cases where this could be a problem would be if a gem or GitHub Action you use were compromised and ran as part of the test job or any other job on main. Because everything is pinned, this is extremely unlikely, but considering that the bundler cache gets you very little benefit here, I think it's a worthwhile tradeoff.