### PR TITLE
fix simplecov warning and minor style in rspec

### DIFF
--- a/spec/savon/features/faraday_transport_options_spec.rb
+++ b/spec/savon/features/faraday_transport_options_spec.rb
@@ -102,11 +102,11 @@ end
 server_cluster = nil
 
 RSpec.describe "Savon Faraday transport - connection options" do
-  before :all do
+  before(:context) do
     server_cluster = FaradayTransportOptionServers.start
   end
 
-  after :all do
+  after(:context) do
     server_cluster&.stop
   end
 

--- a/spec/savon/mock_spec.rb
+++ b/spec/savon/mock_spec.rb
@@ -6,11 +6,11 @@ require "savon/mock/spec_helper"
 RSpec.describe "Savon's mock interface" do
   include Savon::SpecHelper
 
-  before :all do
+  before(:context) do
     savon.mock!
   end
 
-  after :all do
+  after(:context) do
     savon.unmock!
   end
 

--- a/spec/savon/transport/httpi_spec.rb
+++ b/spec/savon/transport/httpi_spec.rb
@@ -86,7 +86,9 @@ RSpec.describe Savon::Transport::HTTPI do
     let(:body)   { "<body/>" }
     let(:locals) { Savon::LocalOptions.new }
 
-    before do HTTPI.stubs(:post).returns(HTTPI::Response.new(200, {}, "ok")) end
+    before do
+      HTTPI.stubs(:post).returns(HTTPI::Response.new(200, {}, "ok"))
+    end
 
     it "returns a Transport::Response" do
       expect(transport.post(url, {}, body, locals)).to be_a(Savon::Transport::Response)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,11 @@ Bundler.setup(:default, :development)
 unless RUBY_PLATFORM =~ /java/
   require "simplecov"
   SimpleCov.start do
-    add_filter "spec"
+    if SimpleCov.respond_to?(:skip)
+      skip "spec"
+    else
+      add_filter "spec"
+    end
   end
 end
 


### PR DESCRIPTION
**What kind of change is this?**

minor refactoring

**Did you add tests for your changes?**

changes were in tests

**Summary of changes**

just working to get my environment back up to speed: I noticed a warning and trying to fix it:

```
vscode ➜ /workspaces/savon (main) $ bundle exec rspec
/workspaces/savon/spec/spec_helper.rb:10:in `block in <top (required)>': [DEPRECATION] `SimpleCov.add_filter` is deprecated. Replace with `SimpleCov.skip` (same arguments, same behavior). Example: `SimpleCov.skip "spec"`.
```

also I see a minor modernization in some of the specs so I updated those too while leaving larger changes alone.



**Other information**

rubocop passes

---

By submitting this pull request, I confirm that my contribution follows Savon's [Code of Conduct](https://github.com/savonrb/savon/blob/main/CODE_OF_CONDUCT.md).
